### PR TITLE
Support `ratio` in `randomSample`, instead of `percentage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,10 @@ test:
 watch:
 	$(PYTEST_CALL) && while $(INOTIFY_CALL); do $(PYTEST_CALL); done
 
+upload:
+	rm -rfv dist
+	rm -rfv powerfulseal.egg-info
+	python setup.py sdist
+	twine upload dist/*
+
 .PHONY: test watch

--- a/powerfulseal/policy/ps-schema.json
+++ b/powerfulseal/policy/ps-schema.json
@@ -78,7 +78,7 @@
                             {"$ref": "#/definitions/actionWait"}
                         ]
                     }
-                },
+                }
             },
             "required": ["name", "match", "filters", "actions"]
         },
@@ -198,7 +198,7 @@
                         },
                         "value": {
                             "type": "string"
-                        },
+                        }
                     },
                     "required": ["name", "value"]
                 }
@@ -214,7 +214,7 @@
             "properties": {
                 "start": {
                     "type": ["object", "null"],
-                    "additionalProperties": false,
+                    "additionalProperties": false
                 }
             },
             "required": ["start"]
@@ -317,7 +317,7 @@
                             {"$ref": "#/definitions/actionWait"}
                         ]
                     }
-                },
+                }
             },
             "required": ["name", "match", "filters", "actions"]
         },
@@ -371,7 +371,7 @@
                     "additionalProperties": false,
                     "properties": {
                         "selector": {
-                            "type": "string",
+                            "type": "string"
                         },
                         "namespace": {
                             "type": "string"
@@ -400,7 +400,7 @@
                         },
                         "value": {
                             "type": "string"
-                        },
+                        }
                     },
                     "required": ["name", "value"]
                 }
@@ -427,6 +427,6 @@
                 }
             },
             "required": ["kill"]
-        },
+        }
     }
 }

--- a/powerfulseal/policy/ps-schema.json
+++ b/powerfulseal/policy/ps-schema.json
@@ -96,7 +96,7 @@
                         "size": {
                             "type": "number"
                         },
-                        "percentage": {
+                        "ratio": {
                             "type": "number"
                         }
                     }

--- a/powerfulseal/policy/scenario.py
+++ b/powerfulseal/policy/scenario.py
@@ -146,14 +146,14 @@ class Scenario():
 
     def filter_random_sample(self, candidates, criterion):
         """ Returns a random sample from the initial list.
-            It supports policy `size` and `percentage` features.
+            It supports policy `size` and `ratio` features.
         """
         if not criterion:
             return []
         size = criterion.get("size")
         if size is None:
-            percentage = criterion.get("percentage")
-            size = int(len(candidates)*percentage)
+            ratio = criterion.get("ratio", 1)
+            size = int(len(candidates)*ratio)
         if size == 0:
             self.logger.info("RandomSample size 0")
             return []

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='1.0.1',
+    version='1.1.0',
     author='Mikolaj Pawlikowski',
     url='https://github.com/bloomberg/powerfulseal',
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     name='powerfulseal',
     version='1.1.0',
     author='Mikolaj Pawlikowski',
+    author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',
     packages=find_packages(),
     license=read('LICENSE'),

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -70,9 +70,9 @@ nodeScenarios:
       - randomSample:
           size: 5
 
-      # or a percentage (will be rounded down to an integer)
+      # or a ratio (will be rounded down to an integer)
       - randomSample:
-          percentage: 0.2
+          ratio: 0.2
 
       # this will pass all the nodes with the given probability,
       # or none otherwise
@@ -149,9 +149,9 @@ podScenarios:
       - randomSample:
           size: 5
 
-      # or a percentage (will be rounded down to an integer)
+      # or a ratio (will be rounded down to an integer)
       - randomSample:
-          percentage: 0.2
+          ratio: 0.2
 
       # this will pass all the nodes with the given probability,
       # or none otherwise

--- a/tests/policy/test_scenario.py
+++ b/tests/policy/test_scenario.py
@@ -168,7 +168,7 @@ def test_random_sample_percentage(noop_scenario):
     candidates = [dummy_object() for x in range(100)]
     for x in range(101):
         percentage = x / 100.00
-        sample = noop_scenario.filter_random_sample(candidates,{"percentage":percentage})
+        sample = noop_scenario.filter_random_sample(candidates,{"ratio":percentage})
         assert len(sample) == int(percentage * len(candidates))
         for elem in sample:
             assert elem in candidates


### PR DESCRIPTION
Modifies the schema, the interpreter and the tests to account for the change.

Closes https://github.com/bloomberg/powerfulseal/issues/15