### PR TITLE
Ssh allow missing host keys

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -68,6 +68,13 @@ def main(argv):
         action='store_true',
     )
 
+    args_ssh.add_argument(
+        '--ssh-allow-missing-host-keys',
+        default=False,
+        action='store_true',
+        help='Allow connection to hosts not present in known_hosts',
+    )
+
     # cloud driver related config
     cloud_options = prog.add_mutually_exclusive_group(required=False)
     cloud_options.add_argument('--open-stack-cloud',
@@ -152,6 +159,7 @@ def main(argv):
     # create an executor
     executor = RemoteExecutor(
         user=args.remote_user,
+        ssh_allow_missing_host_keys=args.ssh_allow_missing_host_keys,
     )
 
     if args.interactive:

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -68,6 +68,13 @@ def main(argv):
         action='store_true',
     )
 
+    # ssh related options
+    args_ssh = prog.add_argument_group('SSH settings')
+    args_ssh.add_argument(
+        '--remote-user',
+        default=os.environ.get("PS_REMOTE_USER", "cloud-user"),
+        help="the of the user for the ssh connections",
+    )
     args_ssh.add_argument(
         '--ssh-allow-missing-host-keys',
         default=False,
@@ -80,10 +87,6 @@ def main(argv):
     cloud_options.add_argument('--open-stack-cloud',
         default=os.environ.get("OPENSTACK_CLOUD"),
         help="the name of the open stack cloud from your config file to use",
-    )
-    prog.add_argument('--remote-user',
-        default=os.environ.get("PS_REMOTE_USER", "cloud-user"),
-        help="the of the user for the ssh connections",
     )
 
     # KUBERNETES CONFIG

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -24,9 +24,13 @@ class RemoteExecutor(object):
 
     PREFIX = ["sh", "-c"]
 
-    def __init__(self, nodes=None, user="cloud-user"):
+    def __init__(self, nodes=None, user="cloud-user",
+                 ssh_allow_missing_host_keys=False):
         self.nodes = nodes or []
         self.user = user
+        self.missing_host_key = (spur.ssh.MissingHostKey.accept
+                                 if ssh_allow_missing_host_keys
+                                 else spur.ssh.MissingHostKey.raise_error)
 
     def execute(self, cmd, nodes=None, debug=False):
         nodes = nodes or self.nodes
@@ -36,6 +40,7 @@ class RemoteExecutor(object):
             shell = spur.SshShell(
                 hostname=node.ip,
                 username=self.user,
+                missing_host_key=self.missing_host_key,
             )
             print("Executing '%s' on %s" % (cmd_full, node.name))
             try:


### PR DESCRIPTION
For certain commands in interactive mode, the powerful seal connects to the host via ssh. If the host is not present in your `known_hosts`, the seal will fail to connect and throw an error of the form:

```
Executing '['sh', '-c', 'sudo docker ']' on sk1-worker-1
--------------------------------------------------------------------------------
xxx.xxx.xxx.xxx


Error creating SSH connection
Original error: Server 'xxx.xxx.xxx.xxx' not found in known_hosts
```

This PR takes an optional command line flag that allows ssh to connect to hosts whose keys are not found in known_hosts

closes #22 