### PR TITLE
Deduplicate nodes

### DIFF
--- a/powerfulseal/node/node.py
+++ b/powerfulseal/node/node.py
@@ -63,3 +63,9 @@ class Node(object):
 
     def __repr__(self):
         return self.__str__()
+
+    def __eq__(self, other):
+        return other.id == self.id
+
+    def __hash__(self):
+        return hash(self.id)

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -56,3 +56,10 @@ def test_node_repr(node):
 def test_node_raises_on_bad_state(state):
     with pytest.raises(ValueError):
         Node(id="something", state=state)
+
+
+def test_nodes_are_deduplicated():
+    collection = set()
+    collection.add(Node(**EXAMPLE_NODE_ARGS))
+    collection.add(Node(**EXAMPLE_NODE_ARGS))
+    assert len(collection) == 1


### PR DESCRIPTION
In certain cases, you could end up with multiple instances of `Node`, that really represent the same node on the cloud. This fixes it.

Closes https://github.com/bloomberg/powerfulseal/issues/4