### PR TITLE
Add Python 2.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.pytest_cache/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 python:
+  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
 
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
+  - pip install tox-travis
 
 # command to run tests
 script:
-  - make test
+  - tox

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 INOTIFY_CALL ?= inotifywait -e modify -r ./powerfulseal ./tests
-PYTEST_CALL ?= pytest --cov powerfulseal/ --cov-report term-missing -vv
+TOX_CALL ?= tox
 
 test:
-	$(PYTEST_CALL)
+	$(TOX_CALL)
 
 watch:
-	$(PYTEST_CALL) && while $(INOTIFY_CALL); do $(PYTEST_CALL); done
+	$(TOX_CALL) && while $(INOTIFY_CALL); do $(TOX_CALL); done
 
 upload:
 	rm -rfv dist

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ pip install powerfulseal
 powerfulseal --help # or seal --help
 ```
 
+## Testing
+
+We use tox to test with multiple Python versions
+
 ## Read about the PowerfulSeal
 
 - https://www.techatbloomberg.com/blog/powerfulseal-testing-tool-kubernetes-clusters/
@@ -97,7 +101,6 @@ powerfulseal --help # or seal --help
 - https://github.com/dastergon/awesome-chaos-engineering#notable-tools
 - https://www.linux.com/news/powerfulseal-testing-tool-kubernetes-clusters-0
 - https://www.infoq.com/news/2018/01/powerfulseal-chaos-kubernetes
-
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Both Python 2.7 and Python 3 are supported.
 
 PowerfulSeal uses [tox](https://github.com/tox-dev/tox) to test with multiple versions on Python. The recommended setup is to install and locally activate the Python versions under `tox.ini` with [pyenv](https://github.com/pyenv/pyenv). 
 
-Once the required Python versions are set up and can be discovered by tox (e.g., by having them discoverable in your PATH), you can run the tests by running `tox`. 
+Once the required Python versions are set up and can be discovered by tox (e.g., by having them discoverable in your PATH), you can run the tests by running `tox`.
+
+More details in [TESTING.md](TESTING.md) 
 
 ## Read about the PowerfulSeal
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ pip install powerfulseal
 powerfulseal --help # or seal --help
 ```
 
+Both Python 2.7 and Python 3 are supported.
+
 ## Testing
 
-We use tox to test with multiple Python versions
+PowerfulSeal uses [tox](https://github.com/tox-dev/tox) to test with multiple versions on Python. The recommended setup is to install and locally activate the Python versions under `tox.ini` with [pyenv](https://github.com/pyenv/pyenv). 
+
+Once the required Python versions are set up and can be discovered by tox (e.g., by having them discoverable in your PATH), you can run the tests by running `tox`. 
 
 ## Read about the PowerfulSeal
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,21 @@
+# Testing `PowerfulSeal`
+
+PowerfulSeal uses [tox](https://github.com/tox-dev/tox) to test multiple Python versions in a straightforward manner, which is especially useful due to the application's compatibility with both Python 2.7 and Python 3.
+
+## Installation
+In order to use `tox`, `tox` must be installed and Python binaries for the versions listed in [tox.ini](tox.ini) (2.7, 3.4, 3.6, 3.7 as of writing) must be visible in your PATH.
+
+Due to the difficulty in maintaining the required libraries for so many Python versions, it is recommended to use [pyenv](https://github.com/pyenv/pyenv) to install and manage multiple versions of Python.
+
+The recommended installation steps are:
+1. Install pyenv using the [Basic GitHub Checkout](https://github.com/pyenv/pyenv#basic-github-checkout) method
+2. Run `pyenv install --list` 
+2. For every version specified in `tox.ini`, find the latest patch version corresponding to the version (e.g., `2.7` -> `2.7.15`) and run `pyenv install [version]`
+4. In this project's root directory, run `pyenv local [versions]`, where `[versions]` is a space-separated list of every version you just installed (e.g., `pyenv install 2.7.15 3.4.8 3.6.5 3.7.0`)
+5. Run `pyenv which 2.7`, `pyenv which 3.4`, etc. and ensure there are no errors and the output path is a `.pyenv` directory 
+
+## Usage
+
+With the installation complete, simply run `tox` (or the analagous `make test`). If you are running on a machine with `inotifywait` installed (i.e., a UNIX machine), you can run `make watch` and run tests automatically when you run changes.
+
+You can also run tests for specific versions by running `tox -e [version(s)]` (e.g., `tox -e py36`). Additionally, if you need to reinstall dependencies, you can use the `-r` flag.

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from __future__ import print_function
 import argparse
 from configargparse import ArgumentParser, YAMLConfigFileParser
 import logging

--- a/powerfulseal/cli/pscmd.py
+++ b/powerfulseal/cli/pscmd.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from __future__ import print_function
 import cmd
 import shlex
 import random

--- a/powerfulseal/cli/pscmd.py
+++ b/powerfulseal/cli/pscmd.py
@@ -78,7 +78,7 @@ class PSCmd(cmd.Cmd):
     """
 
     def __init__(self, inventory, driver, executor, k8s_inventory):
-        super().__init__()
+        cmd.Cmd.__init__(self)
         self.inventory = inventory
         self.driver = driver
         self.prompt = "(seal) $ "

--- a/powerfulseal/clouddrivers/driver.py
+++ b/powerfulseal/clouddrivers/driver.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +13,11 @@
 # limitations under the License.
 
 
-import abc
+import abc, six
 
 
-class AbstractDriver(metaclass=abc.ABCMeta):
+@six.add_metaclass(abc.ABCMeta)
+class AbstractDriver():
     """
         Abstract class representing a cloud driver.
         All concrete drivers should implement this.
@@ -25,20 +25,20 @@ class AbstractDriver(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def sync(self):
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
     @abc.abstractmethod
     def get_by_ip(self, ip):
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
     @abc.abstractmethod
     def stop(self, node):
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
     @abc.abstractmethod
     def start(self, node):
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
     @abc.abstractmethod
     def delete(self, node):
-        pass #pragma: no cover
+        pass  # pragma: no cover

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from __future__ import print_function
 import spur
 
 

--- a/powerfulseal/node/inventory.py
+++ b/powerfulseal/node/inventory.py
@@ -15,7 +15,14 @@
 
 
 import logging
-import configparser
+
+import six
+from six.moves import configparser
+
+if six.PY2:
+    ConfigParser = configparser.SafeConfigParser
+else:
+    ConfigParser = configparser.ConfigParser
 
 
 def read_inventory_file_to_dict(inventory_filename):

--- a/powerfulseal/policy/node_scenario.py
+++ b/powerfulseal/policy/node_scenario.py
@@ -25,7 +25,7 @@ class NodeScenario(Scenario):
 
     def __init__(self, name, schema, inventory, driver,
                  executor, logger=None):
-        super().__init__(name, schema, logger=logger)
+        Scenario.__init__(self, name, schema, logger=logger)
         self.inventory = inventory
         self.driver = driver
         self.executor = executor

--- a/powerfulseal/policy/pod_scenario.py
+++ b/powerfulseal/policy/pod_scenario.py
@@ -25,7 +25,7 @@ class PodScenario(Scenario):
     """
 
     def __init__(self, name, schema, inventory, k8s_inventory, executor, logger=None):
-        super().__init__(name, schema, logger=logger)
+        Scenario.__init__(self, name, schema, logger=logger)
         self.inventory = inventory
         self.k8s_inventory = k8s_inventory
         self.executor = executor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
 mock
+
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pytest
-pytest-cov
-mock
-
--e .

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='1.2.1',
+    version='1.3.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,15 @@ setup(
         'PyYAML>=3.12,<4',
         'jsonschema>=2.6.0,<3',
         'boto3>=1.5.15,<2.0.0',
-        'pytest>=3.0,<4',
-        'pytest-cov>=2.5,<3',
-        'mock>=2,<3',
-        'future>=0.16.0,<1'
+        'future>=0.16.0,<1',
     ],
+    extras_require={
+        'testing': [
+            'pytest>=3.0,<4',
+            'pytest-cov>=2.5,<3',
+            'mock>=2,<3',
+        ]
+    },
     entry_points={
         'console_scripts': [
             'seal = powerfulseal.cli.__main__:start',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ setup(
         'kubernetes>=1.0.0,<2',
         'PyYAML>=3.12,<4',
         'jsonschema>=2.6.0,<3',
-        'boto3>=1.5.15,<2.0.0'
+        'boto3>=1.5.15,<2.0.0',
+        'pytest>=3.0,<4',
+        'pytest-cov>=2.5,<3',
+        'mock>=2,<3',
+        'future>=0.16.0,<1'
     ],
     entry_points={
         'console_scripts': [

--- a/tests/node/test_inventory.py
+++ b/tests/node/test_inventory.py
@@ -20,7 +20,7 @@ from powerfulseal.node.inventory import read_inventory_file_to_dict
 
 
 def test_reads_sample_inventory():
-    filename = pkg_resources.resource_filename('tests.node', 'example_inventory')
+    filename = pkg_resources.resource_filename('node', 'example_inventory')
     groups = read_inventory_file_to_dict(filename)
     assert groups["groupa"] == ["192.168.1.1"]
     assert groups["groupb"] == ["192.168.2.1"]

--- a/tests/node/test_node_inventory.py
+++ b/tests/node/test_node_inventory.py
@@ -15,7 +15,7 @@
 
 
 import pytest
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from powerfulseal.node import Node, NodeInventory
 

--- a/tests/policy/test_node_scenario.py
+++ b/tests/policy/test_node_scenario.py
@@ -15,7 +15,7 @@
 
 
 import pytest
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from powerfulseal.policy.node_scenario import NodeScenario
 

--- a/tests/policy/test_pod_scenario.py
+++ b/tests/policy/test_pod_scenario.py
@@ -16,7 +16,7 @@
 
 import random
 import pytest
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from powerfulseal.policy.pod_scenario import PodScenario
 
@@ -178,7 +178,8 @@ def test_kills_with_probability(pod_scenario, prob):
     for _ in range(sample):
         pod_scenario.act(items)
 
-    assert (mock.call_count/len(items)) / sample == pytest.approx(prob, 0.05)
+    actual_prob = float(mock.call_count / len(items)) / sample
+    assert (actual_prob == pytest.approx(prob, 0.05))
 
 
 def test_doesnt_kill_when_cant_find_node(pod_scenario):

--- a/tests/policy/test_policy_runner.py
+++ b/tests/policy/test_policy_runner.py
@@ -16,20 +16,20 @@
 
 import pytest
 import pkg_resources
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from powerfulseal.policy import PolicyRunner
 
 
 def test_example_config_validates():
-    filename = pkg_resources.resource_filename("tests.policy", "example_config.yml")
+    filename = pkg_resources.resource_filename("policy", "example_config.yml")
     PolicyRunner.validate_file(filename)
 
 
 def test_parses_a_whole_config_correctly(monkeypatch):
     sleep_mock = MagicMock()
     monkeypatch.setattr("time.sleep", sleep_mock)
-    filename = pkg_resources.resource_filename("tests.policy", "example_config2.yml")
+    filename = pkg_resources.resource_filename("policy", "example_config2.yml")
     policy = PolicyRunner.validate_file(filename)
     inventory = MagicMock()
     k8s_inventory = MagicMock()

--- a/tests/policy/test_scenario.py
+++ b/tests/policy/test_scenario.py
@@ -17,7 +17,7 @@
 import random
 import datetime
 import pytest
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from powerfulseal.policy.scenario import Scenario
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py27,py34,py36,py37
+
+[testenv]
+; Install pbr (a dependency of os-service-types) in advance to skip os-service-types
+; running easy_install as easy_install does not preserve parameters (such as proxies)
+; passed into pip.
+deps = pbr
+extras = testing
+commands = pytest
+
+; https://github.com/schematics/schematics/issues/418
+setenv =
+    PYTHONPATH={toxinidir}


### PR DESCRIPTION
This pull request adds Python 2.7 compatibility. 

There are no breaking changes for users. However, the testing workflow has been changed to use tox. Additionally, test packages in `requirements.txt` have been moved to `extras_require` as it is the suggested approach to handling test packages in tox.

Resolves #51, resolves #57.