### PR TITLE
Fix argument parsing with --validate-policy-file (fixes #14)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='1.4.0',
+    version='1.4.1',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/cli/args.py
+++ b/tests/cli/args.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from powerfulseal.cli.__main__ import parse_args
+
+
+def test_validate_policy_file_does_not_require_other_arguments():
+    parser = parse_args(['--validate-policy-file', 'test/config.yml'])
+    assert parser.validate_policy_file == 'test/config.yml'
+
+
+def test_example_arguments():
+    # Interactive mode
+    parser = parse_args['--inventory-kubernetes', '--kube-config',
+                        '~/.kube/config', '--no-cloud', '--interactive']
+    assert parser.inventory_kubernetes
+    assert parser.kube_config == '~/.kube/config'
+    assert parser.no_cloud
+    assert parser.interactive
+
+    # Autonomous mode
+    parser = parse_args['--inventory-kubernetes', '--kube-config',
+                        '~/.kube/config', '--no-cloud', '--run-policy-file',
+                        '~/policy.yml', '--inventory-kubernetes']
+    assert parser.inventory_kubernetes
+    assert parser.kube_config == '~/.kube/config'
+    assert parser.no_cloud
+    assert parser.run_policy_file == '~/policy.yml'
+    assert parser.inventory_kubernetes

--- a/tests/cli/test_args.py
+++ b/tests/cli/test_args.py
@@ -20,19 +20,19 @@ def test_validate_policy_file_does_not_require_other_arguments():
     assert parser.validate_policy_file == 'test/config.yml'
 
 
-def test_example_arguments():
-    # Interactive mode
-    parser = parse_args['--inventory-kubernetes', '--kube-config',
-                        '~/.kube/config', '--no-cloud', '--interactive']
+def test_interactive_mode_integration():
+    parser = parse_args(['--inventory-kubernetes', '--kube-config',
+                        '~/.kube/config', '--no-cloud', '--interactive'])
     assert parser.inventory_kubernetes
     assert parser.kube_config == '~/.kube/config'
     assert parser.no_cloud
     assert parser.interactive
 
-    # Autonomous mode
-    parser = parse_args['--inventory-kubernetes', '--kube-config',
+
+def test_autonomous_mode_integration():
+    parser = parse_args(['--inventory-kubernetes', '--kube-config',
                         '~/.kube/config', '--no-cloud', '--run-policy-file',
-                        '~/policy.yml', '--inventory-kubernetes']
+                        '~/policy.yml', '--inventory-kubernetes'])
     assert parser.inventory_kubernetes
     assert parser.kube_config == '~/.kube/config'
     assert parser.no_cloud


### PR DESCRIPTION
Fixes issue where validating a policy file required other, unused arguments.

All changes are backwards-compatible with previous version. Basic integration tests for the CLI and a test case for issue #14 specifically have also been added.

Signed-off-by: Kelvin Zhang <kzhang302@bloomberg.net>