### PR TITLE
Implement demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ powerfulseal --help # or seal --help
 
 Both Python 2.7 and Python 3 are supported.
 
+### Demo mode
+
+The main way to use PowerfulSeal is to write a policy file for Autonomous mode which reflects realistic failures in your system. However, PowerfulSeal comes with a demo mode to demonstrate how it can cause chaos on your Kubernetes cluster. Demo mode gets all the pods in the cluster, selects those which are using the most resources, then kills them based on a probability.
+
+Demo mode requires [Heapster](https://github.com/kubernetes/heapster). To run demo mode, use the `--demo` flag along with `--heapster-path` (path to heapster without a trailing slash, e.g., `http://localhost:8001/api/v1/namespaces-kube-system/services/heapster/proxy`). You can also optionally specify `--aggressiveness` (from `1` (weakest) to `5` (strongest)) inclusive, as well as `--[min/max]-seconds-between-runs`.
+
+
 ## Testing
 
 PowerfulSeal uses [tox](https://github.com/tox-dev/tox) to test with multiple versions on Python. The recommended setup is to install and locally activate the Python versions under `tox.ini` with [pyenv](https://github.com/pyenv/pyenv). 

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -74,24 +74,39 @@ def parse_args(args):
         help='starts the seal in label mode',
         action='store_true',
     )
+    policy_options.add_argument('--demo',
+        help='starts the demo mode',
+        action='store_true'
+    )
 
     is_validate_policy_file_set = '--validate-policy-file' in args
 
-    # Label mode arguments
-    label_options = prog.add_argument_group()
-    label_options.add_argument('--min-seconds-between-runs',
-        default=0,
-        help='minimum seconds between runs'
+    # Demo mode
+    demo_options = prog.add_argument_group()
+    demo_options.add_argument('--heapster-path',
+        help='Base path of Heapster without trailing slash'
     )
-    label_options.add_argument('--max-seconds-between-runs',
-        default=300,
-        help='maximum seconds between runs'
+    demo_options.add_argument('--aggressiveness',
+        help='Aggressiveness of demo mode (default: 3)',
+        default=3,
+        type=int
     )
 
-    # Specify the namespace for label mode
+    # Arguments for both label and demo mode
     prog.add_argument('--namespace',
         default='default',
-        help='Namespace to use for label mode, defaults to the default namespace (set to blank for all namespaces)'
+        help='Namespace to use for label and demo mode, defaults to the default '
+             'namespace (set to blank for all namespaces)'
+    )
+    prog.add_argument('--min-seconds-between-runs',
+        help='Minimum number of seconds between runs',
+        default=0,
+        type = int
+    )
+    prog.add_argument('--max-seconds-between-runs',
+        help='Maximum number of seconds between runs',
+        default=300,
+        type = int
     )
 
     # Inventory
@@ -189,41 +204,6 @@ def parse_args(args):
         help='Location of kube-config file',
     )
 
-    # Policy
-    policy_options = prog.add_mutually_exclusive_group(required=True)
-    policy_options.add_argument('--validate-policy-file',
-        help='reads the policy file, validates the schema, returns'
-    )
-    policy_options.add_argument('--run-policy-file',
-        default=os.environ.get("POLICY_FILE"),
-        help='location of the policy file to read',
-    )
-    policy_options.add_argument('--interactive',
-        help='will start the seal in interactive mode',
-        action='store_true',
-    )
-    policy_options.add_argument('--demo',
-        help='starts the demo mode',
-        action='store_true'
-    )
-
-    # Demo mode
-    demo_options = prog.add_argument_group()
-    demo_options.add_argument('--heapster-path',
-        help='Base path of Heapster without trailing slash'
-    )
-    demo_options.add_argument('--aggressiveness',
-         help='Aggressiveness of demo mode (default: 3)',
-         default=3
-    )
-    demo_options.add_argument('--min-seconds-between-runs',
-        help='Minimum number of seconds between runs',
-        default=0
-    )
-    demo_options.add_argument('--max-seconds-between-runs',
-        help='Maximum number of seconds between runs',
-        default=300
-    )
     return prog.parse_args(args=args)
 
 
@@ -332,7 +312,8 @@ def main(argv):
         demo_runner = DemoRunner(inventory, k8s_inventory, driver, executor,
                                  heapster_client, aggressiveness=aggressiveness,
                                  min_seconds_between_runs=int(args.min_seconds_between_runs),
-                                 max_seconds_between_runs=int(args.max_seconds_between_runs))
+                                 max_seconds_between_runs=int(args.max_seconds_between_runs),
+                                 namespace=args.namespace)
         demo_runner.run()
     elif args.label:
         label_runner = LabelRunner(inventory, k8s_inventory, driver, executor,

--- a/powerfulseal/k8s/heapster_client.py
+++ b/powerfulseal/k8s/heapster_client.py
@@ -1,0 +1,104 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import requests
+
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
+POD_METRICS_PATH = "/apis/metrics/v1alpha1/pods"
+
+# Value is a fraction of a single CPU core (e.g., 1m = 1 / 1000 => 0.001)
+CPU_UNITS = {'m': 1000}
+# Value is a multiple of a byte (e.g., 1Ki => 1000)
+MEMORY_UNITS = {'Ki': 1000, 'Mi': 1000000, 'Gi': 1000000000, 'Ti': 1000000000000, 'Pi': 1000000000000000}
+
+
+class HeapsterClient:
+    """
+    Retrieves CPU and memory metrics from Heapster
+    """
+
+    def __init__(self, base_path, logger=None):
+        self.base_path = base_path or ''
+        self.logger = logger or logging.getLogger(__name__)
+
+    def get_pod_metrics(self):
+        response = requests.get(self.base_path + POD_METRICS_PATH)
+        if response.status_code != 200:
+            self.logger.error("Could not retrieve pod metrics. Exiting.")
+            exit()
+
+        try:
+            data = response.json()
+        except ValueError:
+            self.logger.error("Unable to retrieve response data. Exiting.")
+            exit()
+
+        # Key: map of namespaces; value: map of pods
+        metrics = {}
+        for item in data['items']:
+            namespace = item['metadata']['namespace']
+            name = item['metadata']['name']
+            cpu = sum(map(lambda c: self.parse_cpu_string(c['usage']['cpu']), item['containers']))
+            memory = sum(map(lambda c: self.parse_memory_string(c['usage']['memory']), item['containers']))
+
+            if namespace not in metrics:
+                metrics[namespace] = {}
+
+            metrics[namespace][name] = {
+                'cpu': cpu,
+                'memory': memory
+            }
+
+        return metrics
+
+    def parse_cpu_string(self, cpu):
+        """
+        Returns CPU in number of cores (e.g., "120m" => 0.12)
+        """
+        if len(cpu) < 2 or is_numeric(cpu[-1]):
+            return float(cpu)
+
+        return float(cpu[:-1]) / CPU_UNITS[cpu[-1:]]
+
+    def parse_memory_string(self, memory):
+        """
+        Returns memory in number of bytes (e.g., "228Ki" => 228000)
+        """
+        if len(memory) < 2:
+            return int(memory)
+
+        is_last_numeric = is_numeric(memory[-1])
+        is_penultimate_numeric = is_numeric(memory[-2])
+        if is_penultimate_numeric and is_last_numeric:
+            # Memory is already in bytes
+            return int(memory)
+        elif not is_penultimate_numeric and is_last_numeric:
+            # Impossible case of alphabetical followed by numeric
+            raise ValueError("Memory is malformed")
+        elif is_penultimate_numeric and not is_last_numeric:
+            # Unimplemented case of single-character suffixes (it is unknown
+            # whether Heapster implements this). Currently, memory is handled
+            # with power-of-two suffixes (e.g., Ki, Mi, etc.)
+            raise NotImplementedError("Single character units are not implemented")
+        else:
+            return int(memory[:-2]) * MEMORY_UNITS[memory[-2:]]
+
+
+def is_numeric(c):
+    return '0' <= c <= '9'

--- a/powerfulseal/policy/demo_runner.py
+++ b/powerfulseal/policy/demo_runner.py
@@ -111,10 +111,6 @@ class DemoRunner:
         return filled_pods
 
     def filter_pods(self, pods):
-        # Fill metrics if metrics to filter on do not already exist
-        if not all(map(lambda p: 'metrics' in p, pods)):
-            raise RuntimeError("Metrics not filled before filtering")
-
         filters = [
             self.filter_top,
             self.filter_probability

--- a/powerfulseal/policy/demo_runner.py
+++ b/powerfulseal/policy/demo_runner.py
@@ -42,7 +42,7 @@ class DemoRunner:
 
     def __init__(self, inventory, k8s_inventory, driver, executor, metric_client,
                  min_seconds_between_runs=0, max_seconds_between_runs=300,
-                 aggressiveness=MIN_AGGRESSIVENESS, logger=None):
+                 aggressiveness=MIN_AGGRESSIVENESS, logger=None, namespace=None):
         self.inventory = inventory
         self.k8s_inventory = k8s_inventory
         self.driver = driver
@@ -52,11 +52,12 @@ class DemoRunner:
         self.aggressiveness = aggressiveness
         self.metric_client = metric_client
         self.logger = logger or logging.getLogger(__name__)
+        self.namespace=None
 
     def run(self):
         while True:
             # Filter
-            all_pods = self.k8s_inventory.get_all_pods()
+            all_pods = self.k8s_inventory.find_pods(self.namespace)
             self.logger.info("Found %d pods" % len(all_pods))
             pods = self.filter_pods(self.fill_metrics(all_pods))
             self.logger.info("Filtered to %d pods" % len(pods))

--- a/powerfulseal/policy/demo_runner.py
+++ b/powerfulseal/policy/demo_runner.py
@@ -1,0 +1,144 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import random
+import time
+
+from powerfulseal.policy.pod_scenario import POD_KILL_CMD_TEMPLATE
+
+MIN_AGGRESSIVENESS = 1
+MAX_AGGRESSIVENESS = 5
+
+
+class DemoRunner:
+    """
+    Kills pods based on CPU core usage and memory usage to demonstrate how chaos
+    can be created by killing pods which are busy.
+
+    The CPU and memory information is retrieved from Heapster. Then, pods are
+    first sorted by their CPU usage and memory and killed based on filters.
+
+    - Pods are first filtered based on what quintile they in: an aggressiveness of
+    1 means that only the top 20% of sorted pods are considered; an aggressiveness of
+    5 means that all nodes are considered.
+    - Pods are then filtered based on a probability which corresponds to an
+    aggressiveness level which is linearly scaled from 10% (1) to 80% (5).
+    """
+
+    HIGHEST_PROBABILITY = 0.8
+    LOWEST_PROBABILITY = 0.1
+    BASE_MINUTES = 10
+
+    def __init__(self, inventory, k8s_inventory, driver, executor, metric_client,
+                 min_seconds_between_runs=0, max_seconds_between_runs=300,
+                 aggressiveness=MIN_AGGRESSIVENESS, logger=None):
+        self.inventory = inventory
+        self.k8s_inventory = k8s_inventory
+        self.driver = driver
+        self.executor = executor
+        self.min_seconds_between_runs = min_seconds_between_runs
+        self.max_seconds_between_runs = max_seconds_between_runs
+        self.aggressiveness = aggressiveness
+        self.metric_client = metric_client
+        self.logger = logger or logging.getLogger(__name__)
+
+    def run(self):
+        while True:
+            # Filter
+            all_pods = self.k8s_inventory.get_all_pods()
+            self.logger.info("Found %d pods" % len(all_pods))
+            pods = self.filter_pods(self.fill_metrics(all_pods))
+            self.logger.info("Filtered to %d pods" % len(pods))
+
+            # Execute
+            for pod in pods:
+                self.kill_pod(pod)
+
+            # Sleep and sync
+            sleep_time = int(random.uniform(self.min_seconds_between_runs, self.max_seconds_between_runs))
+            self.logger.info("Sleeping for %s seconds", sleep_time)
+            time.sleep(sleep_time)
+            self.inventory.sync()
+
+    def kill_pod(self, pod):
+        # Find node
+        node = self.inventory.get_node_by_ip(pod.host_ip)
+        if node is None:
+            self.logger.info("Node not found for pod: %s", pod)
+            return
+
+        # Format command
+        container_id = random.choice(pod.container_ids)
+        cmd = POD_KILL_CMD_TEMPLATE.format(
+            signal="SIGTERM",
+            container_id=container_id.replace("docker://", ""),
+        )
+
+        # Execute command
+        self.logger.info("Action execute '%s' on %r", cmd, pod)
+        for value in self.executor.execute(cmd, nodes=[node]).values():
+            if value["ret_code"] > 0:
+                self.logger.info("Error return code: %s", value)
+
+    def sort_pods(self, pods):
+        return sorted(pods, key=lambda pod: (pod.metrics['cpu'], pod.metrics['memory']), reverse=True)
+
+    def fill_metrics(self, pods):
+        """
+        Adds a metrics variable to each Pod variable in a list of pods. Retrieves
+        the metrics from Heapster.
+        """
+        metrics = self.metric_client.get_pod_metrics()
+        filled_pods = []
+        for pod in pods:
+            try:
+                pod.metrics = metrics[pod.namespace][pod.name]
+                filled_pods.append(pod)
+            except (KeyError, ValueError):
+                self.logger.error("Pod metrics missing for pod %s/%s - skipping" % (pod.namespace, pod.name))
+
+        return filled_pods
+
+    def filter_pods(self, pods):
+        # Fill metrics if metrics to filter on do not already exist
+        if not all(map(lambda p: 'metrics' in p, pods)):
+            raise RuntimeError("Metrics not filled before filtering")
+
+        filters = [
+            self.filter_top,
+            self.filter_probability
+        ]
+
+        remaining_pods = pods
+        for pod_filter in filters:
+            remaining_pods = pod_filter(remaining_pods)
+
+        return remaining_pods
+
+    def filter_top(self, pods):
+        num_pods = int(len(pods) * float(self.aggressiveness / float(MAX_AGGRESSIVENESS)))
+        return pods[0:num_pods]
+
+    def filter_probability(self, pods):
+        boundary = self.LOWEST_PROBABILITY + \
+                   ((self.HIGHEST_PROBABILITY - self.LOWEST_PROBABILITY) / (MAX_AGGRESSIVENESS - MIN_AGGRESSIVENESS)) * \
+                   (self.aggressiveness - MIN_AGGRESSIVENESS)
+        remaining_pods = []
+
+        for pod in pods:
+            p = random.random()
+            if boundary >= p:
+                remaining_pods.append(pod)
+
+        return remaining_pods

--- a/powerfulseal/policy/pod_scenario.py
+++ b/powerfulseal/policy/pod_scenario.py
@@ -34,7 +34,7 @@ class PodScenario(Scenario):
         self.inventory = inventory
         self.k8s_inventory = k8s_inventory
         self.executor = executor
-        self.cmd_template = "sudo docker kill -s {signal} {container_id}"
+        self.cmd_template = POD_KILL_CMD_TEMPLATE
 
     def match(self):
         """ Makes a union of all the pods matching any of the policy criteria.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='1.5.0',
+    version='1.6.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'jsonschema>=2.6.0,<3',
         'boto3>=1.5.15,<2.0.0',
         'future>=0.16.0,<1',
-        'requests>=2.19.1,<3'
+        'requests>=2.19.1,<3',
         'prometheus_client>=0.3.0,<1'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'jsonschema>=2.6.0,<3',
         'boto3>=1.5.15,<2.0.0',
         'future>=0.16.0,<1',
+        'requests>=2.19.1,<3'
         'prometheus_client>=0.3.0,<1'
     ],
     extras_require={

--- a/tests/k8s/test_heapster_client.py
+++ b/tests/k8s/test_heapster_client.py
@@ -1,0 +1,119 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import mock
+import pytest
+
+from powerfulseal.k8s.heapster_client import HeapsterClient
+
+
+def test_get_pod_metrics():
+    heapster = HeapsterClient(None)
+
+    def mocked_response(*args):
+        mocked = mock.MagicMock()
+        mocked.status_code = 200
+        mocked.json = lambda: json.loads("""
+{
+  "metadata": {},
+  "items": [
+    {
+      "metadata": {
+        "name": "abc",
+        "namespace": "default"
+      },
+      "containers": [
+        {
+          "name": "container-1a",
+          "usage": {
+            "cpu": "1m",
+            "memory": "68896Ki"
+          }
+        },
+        {
+          "name": "container-1b",
+          "usage": {
+            "cpu": "1m",
+            "memory": "2Ki"
+          }
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "name": "def",
+        "namespace": "default"
+      },
+      "containers": [
+        {
+          "name": "container-2a",
+          "usage": {
+            "cpu": "3m",
+            "memory": "36840Ki"
+          }
+        }
+      ]
+    }
+  ]
+}
+          """)
+        return mocked
+
+    with mock.patch('powerfulseal.k8s.heapster_client.requests.get',
+                    side_effect=mocked_response):
+        result = heapster.get_pod_metrics()
+        assert len(result) == 1 and 'default' in result
+        assert len(result['default']) == 2
+        assert result == {
+            'default': {
+                'abc': {
+                    'cpu': 0.002,
+                    'memory': 68898000
+                },
+                'def': {
+                    'cpu': 0.003,
+                    'memory': 36840000
+                }
+            }
+        }
+
+
+def test_parse_cpu_string():
+    heapster = HeapsterClient(None)
+    assert heapster.parse_cpu_string('1') == pytest.approx(1)
+    assert heapster.parse_cpu_string('100') == pytest.approx(100)
+    assert heapster.parse_cpu_string('1m') == pytest.approx(0.001)
+    assert heapster.parse_cpu_string('10m') == pytest.approx(0.01)
+
+
+def test_parse_memory_string():
+    heapster = HeapsterClient(None)
+    assert heapster.parse_memory_string('68896') == 68896
+    assert heapster.parse_memory_string('68896Mi') == 68896000000
+    assert heapster.parse_memory_string('68896Ki') == 68896000
+    assert heapster.parse_memory_string('68Gi') == 68000000000
+    assert heapster.parse_memory_string('2Ti') == 2000000000000
+    assert heapster.parse_memory_string('1') == 1
+    assert heapster.parse_memory_string('0') == 0
+    assert heapster.parse_memory_string('16') == 16
+
+    with pytest.raises(NotImplementedError) as _:
+        heapster.parse_memory_string('6889M')
+
+    with pytest.raises(ValueError) as _:
+        heapster.parse_memory_string('688M9')
+
+    with pytest.raises(KeyError) as _:
+        heapster.parse_memory_string('688Ei')

--- a/tests/policy/test_demo_runner.py
+++ b/tests/policy/test_demo_runner.py
@@ -1,0 +1,101 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+
+import pytest
+from mock import MagicMock
+
+from powerfulseal.execute import RemoteExecutor
+from powerfulseal.node import NodeInventory, Node
+from powerfulseal.policy.demo_runner import DemoRunner
+
+
+def test_kill_pod():
+    demo_runner = DemoRunner(NodeInventory(None), None, None, RemoteExecutor(), None)
+
+    # Patch action of getting nodes to execute kill command on
+    test_node = Node(1)
+    get_node_by_ip_mock = MagicMock(return_value=test_node)
+    demo_runner.inventory.get_node_by_ip = get_node_by_ip_mock
+
+    # Patch action of choosing container
+    execute_mock = MagicMock()
+    demo_runner.executor.execute = execute_mock
+
+    mock_pod = MagicMock()
+    mock_pod.container_ids = ["docker://container1"]
+    demo_runner.kill_pod(mock_pod)
+
+    mock_pod = MagicMock()
+    mock_pod.container_ids = ["docker://container1"]
+    demo_runner.kill_pod(mock_pod)
+
+    execute_mock.assert_called_with("sudo docker kill -s SIGTERM container1", nodes=[test_node])
+
+
+def test_sort_pods():
+    pod_1 = MagicMock()
+    pod_1.metrics = {
+        'cpu': 10,
+        'memory': 0
+    }
+
+    pod_2 = MagicMock()
+    pod_2.metrics = {
+        'cpu': 5,
+        'memory': 3
+    }
+
+    pod_3 = MagicMock()
+    pod_3.metrics = {
+        'cpu': 5,
+        'memory': 2
+    }
+
+    demo_runner = DemoRunner(NodeInventory(None), None, None, RemoteExecutor(), None)
+    assert demo_runner.sort_pods([pod_2, pod_3, pod_1]) == [pod_1, pod_2, pod_3]
+
+
+def test_filter_top():
+    first_quintile_runner = DemoRunner(None, None, None, None, None, aggressiveness=1)
+    assert len(first_quintile_runner.filter_top([MagicMock() for _ in range(5)])) == 1
+    assert len(first_quintile_runner.filter_top([MagicMock() for _ in range(10)])) == 2
+    assert len(first_quintile_runner.filter_top([MagicMock() for _ in range(3)])) == 0
+    
+    third_quintile_runner = DemoRunner(None, None, None, None, None, aggressiveness=3)
+    assert len(third_quintile_runner.filter_top([MagicMock() for _ in range(5)])) == 3
+    assert len(third_quintile_runner.filter_top([MagicMock() for _ in range(10)])) == 6
+    assert len(third_quintile_runner.filter_top([MagicMock() for _ in range(3)])) == 1
+
+    all_runner = DemoRunner(NodeInventory(None), None, None, None, None, aggressiveness=5)
+    assert len(all_runner.filter_top([MagicMock() for _ in range(5)])) == 5
+    assert len(all_runner.filter_top([MagicMock() for _ in range(10)])) == 10
+    assert len(all_runner.filter_top([MagicMock() for _ in range(3)])) == 3
+
+
+@pytest.mark.parametrize('case', [
+    (1, 0.1),
+    (2, 0.275),
+    (3, 0.45),
+    (4, 0.625),
+    (5, 0.8)
+])
+def test_filter_probability(case):
+    random.seed(12)
+    sample = 1000
+
+    runner = DemoRunner(None, None, None, None, None, aggressiveness=case[0])
+    filtered_items = runner.filter_probability([MagicMock() for _ in range(sample)])
+    assert pytest.approx(case[1] * sample, 1) == len(filtered_items)
+


### PR DESCRIPTION
This PR implements demo mode, which is aimed at killing the busiest pods in the cluster in order to inflict the most chaos and demonstrate the effects of PowerfulSeal.

This PR is backwards-compatible with the last minor version.

The algorithm used is that the aggregate of CPU and memory usage per pod (across all of a pod's containers) calculated and pods are sorted descending (CPU, then memory). Then, depending on the aggressiveness (between 1 [weakest] and 5 [strongest] inclusive), the proportion of pods to kill is calculated, then pods are filtered even further based on probability. The result is that the busiest pods (in terms of CPU and memory) are killed with an element of randomness.

The implementation of this depends on [Heapster](https://github.com/kubernetes/heapster), which is currently installed on the test cluster. `cadvisor` is also present on all nodes and was the initial intended service to query. However, `cadvisor` only exposes per-node metrics, whereas Heapster aggregates metrics across all nodes.

The approach taken is limited to CPU and memory (as opposed to disk + network) due to the way Heapster exposes metrics over HTTP: one way (used in this implementation) is to query an endpoint once which returns all CPU/memory; the alternative way is to make a single query _per pod per metric_, which doesn't appear to be the intended use of such an endpoint (for four metrics * ~70 pods on the test cluster).