### PR TITLE
Chore - add more test coverage for aws_driver

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -9,10 +9,10 @@ Due to the difficulty in maintaining the required libraries for so many Python v
 
 The recommended installation steps are:
 1. Install pyenv using the [Basic GitHub Checkout](https://github.com/pyenv/pyenv#basic-github-checkout) method
-2. Run `pyenv install --list` 
-2. For every version specified in `tox.ini`, find the latest patch version corresponding to the version (e.g., `2.7` -> `2.7.15`) and run `pyenv install [version]`
+2. Run `pyenv install --list`
+3. For every version specified in `tox.ini`, find the latest patch version corresponding to the version (e.g., `2.7` -> `2.7.15`) and run `pyenv install [version]`
 4. In this project's root directory, run `pyenv local [versions]`, where `[versions]` is a space-separated list of every version you just installed (e.g., `pyenv install 2.7.15 3.4.8 3.6.5 3.7.0`)
-5. Run `pyenv which 2.7`, `pyenv which 3.4`, etc. and ensure there are no errors and the output path is a `.pyenv` directory 
+5. Run `pyenv which 2.7`, `pyenv which 3.4`, etc. and ensure there are no errors and the output path is a `.pyenv` directory
 
 ## Usage
 

--- a/powerfulseal/clouddrivers/aws_driver.py
+++ b/powerfulseal/clouddrivers/aws_driver.py
@@ -10,9 +10,7 @@ def create_connection_from_config():
     return conn
 
 def get_all_ips(instance):
-    """
-        Digs out all the IPs from the instance.private_ip_address field
-        of an AWS EC2 instances
+    """ Returns the private and public ip address of an AWS EC2 instances
     """
     output = []
     output.append(instance.private_ip_address)
@@ -62,7 +60,7 @@ class AWSDriver(AbstractDriver):
         self.logger.info("Fetched %s remote servers" % len(self.amount_of_servers))
 
     def get_by_ip(self, ip):
-        """ Retreive an instance of Node by its IP.
+        """ Retrieve an instance of Node by its IP.
         """
         for server in self.remote_servers:
             addresses = get_all_ips(server)

--- a/tests/clouddrivers/test_aws_driver.py
+++ b/tests/clouddrivers/test_aws_driver.py
@@ -3,7 +3,9 @@ from mock import patch, MagicMock
 from powerfulseal.clouddrivers import aws_driver
 from powerfulseal.node import Node
 
-IPS = ['198.168.1.1', '198.168.2.1']
+PRIVATE_IPS = ['198.168.1.1', '198.168.2.1']
+PUBLIC_IPS = ['31.31.31.31', '41.41.41.41']
+INVALID_IP = '198.168.3.1'
 
 class EC2instance():
     def __init__(self, id, private_ip_address, public_ip_address, zone, state):
@@ -22,10 +24,28 @@ def ec2_instances():
 ]
 
 @patch('powerfulseal.clouddrivers.aws_driver.create_connection_from_config')
-def test_aws_driver(create_connection_from_config, ec2_instances):
-    some = aws_driver.AWSDriver()
-    some.remote_servers = ec2_instances
-    nodes = some.get_by_ip(IPS[0])
-    assert ec2_instances[0].id is nodes.id
-    assert ec2_instances[0].placement['AvailabilityZone'] is nodes.az
-    assert ec2_instances[0].private_ip_address == nodes.ip
+def test_get_by_ip_private_ip_nodes(create_connection_from_config, ec2_instances):
+    driver = aws_driver.AWSDriver()
+    driver.remote_servers = ec2_instances
+    node_index = 0
+    nodes = driver.get_by_ip(PRIVATE_IPS[node_index])
+    assert ec2_instances[node_index].id is nodes.id
+    assert ec2_instances[node_index].placement['AvailabilityZone'] is nodes.az
+    assert ec2_instances[node_index].private_ip_address == nodes.ip
+
+@patch('powerfulseal.clouddrivers.aws_driver.create_connection_from_config')
+def test_get_by_ip_public_ip_nodes(create_connection_from_config, ec2_instances):
+    driver = aws_driver.AWSDriver()
+    driver.remote_servers = ec2_instances
+    node_index = 1
+    nodes = driver.get_by_ip(PUBLIC_IPS[node_index])
+    assert ec2_instances[node_index].id is nodes.id
+    assert ec2_instances[node_index].placement['AvailabilityZone'] is nodes.az
+    assert ec2_instances[node_index].public_ip_address == nodes.ip
+
+@patch('powerfulseal.clouddrivers.aws_driver.create_connection_from_config')
+def test_get_by_ip_no_nodes(create_connection_from_config, ec2_instances):
+    driver = aws_driver.AWSDriver()
+    driver.remote_servers = ec2_instances
+    nodes = driver.get_by_ip(INVALID_IP)
+    assert nodes is None


### PR DESCRIPTION
Description:
Adding a couple tests around aws driver.
- Adds test to check that nodes can be created via public ip address
- Adds test to assert that no nodes are returned if fetching ec2 instances with an invalid ip address

Testing checklist:
- [x] Ran tests locally via tox


