### PR TITLE
Fix prometheus metrics not passing tests

### DIFF
--- a/powerfulseal/policy/label_runner.py
+++ b/powerfulseal/policy/label_runner.py
@@ -142,7 +142,7 @@ class LabelRunner:
             start_time_label = pod.labels.get("seal/start-time", "10-00-00")
             try:
                 hours, minutes, seconds = self.process_time_label(start_time_label)
-                start_time = now.replace(hour=hours, minute=minutes, second=seconds)
+                start_time = now.replace(hour=hours, minute=minutes, second=seconds, microsecond=0)
                 if now < start_time:
                     continue
             except ValueError:
@@ -153,7 +153,7 @@ class LabelRunner:
             end_time_label = pod.labels.get("seal/end-time", "17-30-00")
             try:
                 hours, minutes, seconds = self.process_time_label(end_time_label)
-                end_time = now.replace(hour=hours, minute=minutes, second=seconds)
+                end_time = now.replace(hour=hours, minute=minutes, second=seconds, microsecond=0)
                 if now >= end_time:
                     continue
             except ValueError:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'boto3>=1.5.15,<2.0.0',
         'future>=0.16.0,<1',
         'requests>=2.19.1,<3',
-        'prometheus_client>=0.3.0,<1'
+        'prometheus_client>=0.3.0,<0.4.0'
     ],
     extras_require={
         'testing': [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -23,10 +23,12 @@ from powerfulseal.policy.scenario import Scenario
 class Dummy():
     pass
 
+def make_dummy_object():
+    return Dummy()
 
 @pytest.fixture
 def dummy_object():
-    return Dummy()
+    return make_dummy_object()
 
 
 # Scenario fixtures

--- a/tests/metriccollectors/test_collector.py
+++ b/tests/metriccollectors/test_collector.py
@@ -25,7 +25,7 @@ from tests.fixtures import noop_scenario
 from tests.fixtures import pod_scenario
 # noinspection PyUnresolvedReferences
 from tests.fixtures import node_scenario
-from tests.fixtures import dummy_object
+from tests.fixtures import make_dummy_object
 
 
 # test_collector.py tests to ensure that add_*_metric functions are called when
@@ -188,7 +188,7 @@ def test_add_probability_filter_passed_no_nodes_metric(noop_scenario):
     """
     assert noop_scenario.name == "test scenario"
     random.seed(6)  # make the tests deterministic
-    candidates = [dummy_object()]
+    candidates = [make_dummy_object()]
 
     with mock.patch('powerfulseal.metriccollectors.StdoutCollector.add_probability_filter_passed_no_nodes_filter') \
             as metric_function:

--- a/tests/metriccollectors/test_prometheus_collector.py
+++ b/tests/metriccollectors/test_prometheus_collector.py
@@ -24,7 +24,7 @@ from powerfulseal.metriccollectors.prometheus_collector import STATUS_SUCCESS, \
     EXECUTE_FAILED_METRIC_NAME, FILTERED_TO_EMPTY_SET_METRIC_NAME, \
     PROBABILITY_FILTER_NOT_PASSED_METRIC_NAME, MATCHED_TO_EMPTY_SET_METRIC_NAME
 # noinspection PyUnresolvedReferences
-from tests.fixtures import node_scenario, dummy_object
+from tests.fixtures import node_scenario, make_dummy_object
 # noinspection PyUnresolvedReferences
 from tests.fixtures import noop_scenario
 # noinspection PyUnresolvedReferences
@@ -290,7 +290,7 @@ def test_add_probability_filter_passed_no_nodes_metric(prometheus_noop_scenario)
     """
     assert prometheus_noop_scenario.name == "test scenario"
     random.seed(6)  # make the tests deterministic
-    candidates = [dummy_object()]
+    candidates = [make_dummy_object()]
 
     before = REGISTRY.get_sample_value(PROBABILITY_FILTER_NOT_PASSED_METRIC_NAME)
     assert before == 0

--- a/tests/policy/test_label_runner.py
+++ b/tests/policy/test_label_runner.py
@@ -110,7 +110,8 @@ def test_filter_day_time():
     pod = MagicMock
     pod.labels = {
         "seal/start-time": "10-00-00",
-        "seal/end-time": "17-30-00"
+        "seal/end-time": "17-30-00",
+        "seal/days": "mon,tue,wed,thu,fri,sat,sun"
     }
 
     now = datetime.now()

--- a/tests/policy/test_label_runner.py
+++ b/tests/policy/test_label_runner.py
@@ -114,19 +114,24 @@ def test_filter_day_time():
         "seal/days": "mon,tue,wed,thu,fri,sat,sun"
     }
 
-    now = datetime.now().replace(microsecond=0)
-    test_cases = [
-        (now.replace(hour=8, minute=0, second=0), False, "far too early"),
-        (now.replace(hour=9, minute=59, second=59), False, "just too early"),
-        (now.replace(hour=10, minute=0, second=0), True, "inclusive start"),
-        (now.replace(hour=13, minute=0, second=0), True, "within"),
-        (now.replace(hour=17, minute=30, second=0), False, "exclusive end"),
-        (now.replace(hour=17, minute=30, second=1), False, "just too late"),
-        (now.replace(hour=20, minute=0, second=0), False, "far too late")
-    ]
+    for day in range(7):
+        now = datetime.now()
+        # check that it works for all the days of the week, as specified above
+        now.replace(day=day+1)
+        # set the microseconds to 0, to pass the inclusive start
+        now.replace(microsecond=0)
+        test_cases = [
+            (now.replace(hour=8, minute=0, second=0), False, "far too early"),
+            (now.replace(hour=9, minute=59, second=59), False, "just too early"),
+            (now.replace(hour=10, minute=0, second=0), True, "inclusive start"),
+            (now.replace(hour=13, minute=0, second=0), True, "within"),
+            (now.replace(hour=17, minute=30, second=0), False, "exclusive end"),
+            (now.replace(hour=17, minute=30, second=1), False, "just too late"),
+            (now.replace(hour=20, minute=0, second=0), False, "far too late")
+        ]
 
-    for test_case in test_cases:
-        assert (len(label_runner.filter_day_time([pod], test_case[0])) == 1) == test_case[1]
+        for test_case in test_cases:
+            assert (len(label_runner.filter_day_time([pod], test_case[0])) == 1) == test_case[1]
 
 
 def test_get_integer_days_from_days_label():

--- a/tests/policy/test_label_runner.py
+++ b/tests/policy/test_label_runner.py
@@ -114,7 +114,7 @@ def test_filter_day_time():
         "seal/days": "mon,tue,wed,thu,fri,sat,sun"
     }
 
-    now = datetime.now()
+    now = datetime.now().replace(microsecond=0)
     test_cases = [
         (now.replace(hour=8, minute=0, second=0), False, "far too early"),
         (now.replace(hour=9, minute=59, second=59), False, "just too early"),

--- a/tests/policy/test_node_scenario.py
+++ b/tests/policy/test_node_scenario.py
@@ -18,11 +18,11 @@ from mock import MagicMock
 
 # noinspection PyUnresolvedReferences
 from tests.fixtures import node_scenario
-from tests.fixtures import dummy_object
+from tests.fixtures import make_dummy_object
 
 
 def test_matching_matches(node_scenario):
-    a, b = dummy_object(), dummy_object()
+    a, b = make_dummy_object(), make_dummy_object()
     a.attr = "a - this should match"
     b.attr = "b - this won't"
     node_scenario.schema = {
@@ -41,7 +41,7 @@ def test_matching_matches(node_scenario):
 
 
 def test_matching_returns_things_once_if_multimatch(node_scenario):
-    a, b = dummy_object(), dummy_object()
+    a, b = make_dummy_object(), make_dummy_object()
     a.attr = "a - this should match"
     b.attr = "b - this won't"
     node_scenario.schema = {

--- a/tests/policy/test_pod_scenario.py
+++ b/tests/policy/test_pod_scenario.py
@@ -21,11 +21,11 @@ from mock import MagicMock
 
 # noinspection PyUnresolvedReferences
 from tests.fixtures import pod_scenario
-from tests.fixtures import dummy_object
+from tests.fixtures import make_dummy_object
 
 
 def test_matching_namespace(pod_scenario):
-    a, b = dummy_object(), dummy_object()
+    a, b = make_dummy_object(), make_dummy_object()
     pod_scenario.schema = {
         "match": [
             {
@@ -41,7 +41,7 @@ def test_matching_namespace(pod_scenario):
     assert pod_scenario.k8s_inventory.find_pods.call_args[1] == {"namespace": "something"}
 
 def test_matching_deployment(pod_scenario):
-    a, b = dummy_object(), dummy_object()
+    a, b = make_dummy_object(), make_dummy_object()
     pod_scenario.schema = {
         "match": [
             {
@@ -61,7 +61,7 @@ def test_matching_deployment(pod_scenario):
     }
 
 def test_matching_labels(pod_scenario):
-    a, b = dummy_object(), dummy_object()
+    a, b = make_dummy_object(), make_dummy_object()
     pod_scenario.schema = {
         "match": [
             {

--- a/tests/policy/test_scenario.py
+++ b/tests/policy/test_scenario.py
@@ -22,7 +22,7 @@ import pytest
 
 # noinspection PyUnresolvedReferences
 from tests.fixtures import noop_scenario
-from tests.fixtures import dummy_object
+from tests.fixtures import make_dummy_object, dummy_object
 
 
 def test_empty_property_criteria_dont_match(noop_scenario):
@@ -45,9 +45,9 @@ def test_matches_list_types(noop_scenario, dummy_object, query, should_match):
 
 def test_filter_property(noop_scenario):
     ATTR_NAME = "test"
-    dummy1 = dummy_object()
+    dummy1 = make_dummy_object()
     setattr(dummy1, ATTR_NAME, "yes")
-    dummy2 = dummy_object()
+    dummy2 = make_dummy_object()
     setattr(dummy2, ATTR_NAME, "no")
     criterion = {
         "name": ATTR_NAME,
@@ -90,7 +90,7 @@ def test_filter_day_time_day_of_the_week(noop_scenario, some_datetime, day, shou
             "second": 59
         },
     }
-    candidates = [dummy_object(), dummy_object()]
+    candidates = [make_dummy_object(), make_dummy_object()]
     if should_pass:
         assert noop_scenario.filter_day_time(candidates, criterion, now=some_datetime) == candidates
     else:
@@ -127,7 +127,7 @@ def test_filter_day_time_of_day(noop_scenario, some_datetime, hour, minute,secon
             "second": 15
         },
     }
-    candidates = [dummy_object(), dummy_object()]
+    candidates = [make_dummy_object(), make_dummy_object()]
     if should_pass:
         assert noop_scenario.filter_day_time(candidates, criterion, now=some_datetime) == candidates
     else:
@@ -135,7 +135,7 @@ def test_filter_day_time_of_day(noop_scenario, some_datetime, hour, minute,secon
 
 
 def test_random_sample_size(noop_scenario):
-    candidates = [dummy_object() for x in range(100)]
+    candidates = [make_dummy_object() for x in range(100)]
     for x in range(len(candidates)+1):
         sample = noop_scenario.filter_random_sample(candidates,{"size":x})
         assert len(sample) == x
@@ -144,7 +144,7 @@ def test_random_sample_size(noop_scenario):
 
 
 def test_random_sample_percentage(noop_scenario):
-    candidates = [dummy_object() for x in range(100)]
+    candidates = [make_dummy_object() for x in range(100)]
     for x in range(101):
         percentage = x / 100.00
         sample = noop_scenario.filter_random_sample(candidates,{"ratio":percentage})
@@ -154,7 +154,7 @@ def test_random_sample_percentage(noop_scenario):
 
 
 def test_random_doesnt_pass_on_empty_criterion(noop_scenario):
-    candidates = [dummy_object() for x in range(100)]
+    candidates = [make_dummy_object() for x in range(100)]
     for x in range(101):
         sample = noop_scenario.filter_random_sample(candidates,None)
         assert len(sample) == 0
@@ -169,7 +169,7 @@ def test_random_doesnt_pass_on_empty_criterion(noop_scenario):
 def test_filter_probability(noop_scenario, proba):
     random.seed(7) # make the tests deterministic
     SAMPLES = 100000
-    candidates = [dummy_object(), dummy_object()]
+    candidates = [make_dummy_object(), make_dummy_object()]
     agg_len = 0.0
     criterion = {"probabilityPassAll": proba}
     for _ in range(SAMPLES):
@@ -192,7 +192,7 @@ def test_action_wait(monkeypatch, noop_scenario, sleep_time):
 
 
 def test_filter_mapping_uses_the_mapping(noop_scenario):
-    dummy = dummy_object()
+    dummy = make_dummy_object()
     items = [dummy]
     mapping = {
         "filterA": MagicMock(return_value=items),
@@ -211,7 +211,7 @@ def test_filter_mapping_uses_the_mapping(noop_scenario):
 
 
 def test_acts_mapping_only_waits_once(noop_scenario):
-    items = [dummy_object(), dummy_object()]
+    items = [make_dummy_object(), make_dummy_object()]
     mapping = {
         "wait": MagicMock(return_value=[]),
     }
@@ -220,4 +220,3 @@ def test_acts_mapping_only_waits_once(noop_scenario):
     ]
     noop_scenario.act_mapping(items, actions, mapping)
     assert mapping.get("wait").call_count == 1
-


### PR DESCRIPTION
This was initially to see why the prometheus tests started failing, but later scope creeped fixing some warnings from pytests, and a test that wouldn't work on the weekends, but worked fined on a work day.

Also, fixed an issue with sub-second resolution for the label-based usage.