### PR TITLE
Issue #32 populate container names

### DIFF
--- a/powerfulseal/k8s/k8s_inventory.py
+++ b/powerfulseal/k8s/k8s_inventory.py
@@ -92,6 +92,10 @@ class K8sInventory():
                     status.container_id
                     for status in item.status.container_statuses
                 ] if item.status.container_statuses else [],
+                container_names=[
+                    status.name
+                    for status in item.status.container_statuses
+                ] if item.status.container_statuses else [],
                 restart_count=sum([
                     status.restart_count
                     for status in item.status.container_statuses

--- a/powerfulseal/k8s/pod.py
+++ b/powerfulseal/k8s/pod.py
@@ -22,7 +22,8 @@ class Pod():
     """
 
     def __init__(self, name, namespace, num=None, uid=None, host_ip=None, ip=None,
-                container_ids=None, restart_count=None, state=None, labels=None, meta=None):
+                container_ids=None, container_names=None, restart_count=None, state=None,
+                labels=None, meta=None):
         self.name = name
         self.namespace = namespace
         self.num = num
@@ -30,6 +31,7 @@ class Pod():
         self.host_ip = host_ip
         self.ip = ip
         self.container_ids = container_ids or []
+        self.container_names = container_names or []
         self.restart_count = restart_count or 0
         self.state = state
         self.labels = labels or dict()


### PR DESCRIPTION
This changeset adds an attribute (container_names) to the Pod object.

It is a list of strings (container names in a pod) that can be used with kubectl (or k8s API) to kill pods

From my experimentation this will be needed to support issue #32 