### PR TITLE
add ssh password options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ usage: seal interactive [-h] --kubeconfig KUBECONFIG
                         [--remote-user REMOTE_USER]
                         [--ssh-allow-missing-host-keys]
                         [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
+                        [--ssh-password SSH_PASSWORD]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -94,6 +95,8 @@ SSH settings:
                         Allow connection to hosts not present in known_hosts
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
+  --ssh-password SSH_PASSWORD
+                        ssh password
 ```
 
 
@@ -122,6 +125,7 @@ usage: seal autonomous [-h] --kubeconfig KUBECONFIG
                        [--remote-user REMOTE_USER]
                        [--ssh-allow-missing-host-keys]
                        [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
+                       [--ssh-password SSH_PASSWORD]
                        --policy-file POLICY_FILE
                        [--stdout-collector | --prometheus-collector]
                        [--prometheus-host PROMETHEUS_HOST]
@@ -156,6 +160,8 @@ SSH settings:
                         Allow connection to hosts not present in known_hosts
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
+  --ssh-password SSH_PASSWORD
+                        ssh password
 
 Policy settings:
   --policy-file POLICY_FILE
@@ -258,6 +264,7 @@ usage: seal label [-h] --kubeconfig KUBECONFIG
                   (-i INVENTORY_FILE | --inventory-kubernetes)
                   [--remote-user REMOTE_USER] [--ssh-allow-missing-host-keys]
                   [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
+                  [--ssh-password SSH_PASSWORD]
                   [--kubernetes-namespace KUBERNETES_NAMESPACE]
                   [--min-seconds-between-runs MIN_SECONDS_BETWEEN_RUNS]
                   [--max-seconds-between-runs MAX_SECONDS_BETWEEN_RUNS]
@@ -293,6 +300,8 @@ SSH settings:
                         Allow connection to hosts not present in known_hosts
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
+  --ssh-password SSH_PASSWORD
+                        ssh password
 
 Kubernetes options:
   --kubernetes-namespace KUBERNETES_NAMESPACE
@@ -335,6 +344,7 @@ usage: seal demo [-h] --kubeconfig KUBECONFIG
                  (-i INVENTORY_FILE | --inventory-kubernetes)
                  [--remote-user REMOTE_USER] [--ssh-allow-missing-host-keys]
                  [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
+                 [--ssh-password SSH_PASSWORD]
                  [--kubernetes-namespace KUBERNETES_NAMESPACE]
                  [--min-seconds-between-runs MIN_SECONDS_BETWEEN_RUNS]
                  [--max-seconds-between-runs MAX_SECONDS_BETWEEN_RUNS]
@@ -371,6 +381,8 @@ SSH settings:
                         Allow connection to hosts not present in known_hosts
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
+  --ssh-password SSH_PASSWORD
+                        ssh password
 
 Kubernetes options:
   --kubernetes-namespace KUBERNETES_NAMESPACE
@@ -436,6 +448,7 @@ seal \
     --ssh-allow-missing-host-keys \
     --remote-user docker \
     --ssh-path-to-private-key `minikube ssh-key` \
+    --ssh-password `minikube ssh-password` \
     --override-ssh-host `minikube ip`
 ```
 
@@ -452,6 +465,7 @@ seal \
     --ssh-allow-missing-host-keys \
     --remote-user docker \
     --ssh-path-to-private-key `minikube ssh-key` \
+    --ssh-password `minikube ssh-password` \
     --override-ssh-host `minikube ip`
 ```
 
@@ -470,6 +484,7 @@ seal \
     --ssh-allow-missing-host-keys \
     --remote-user docker \
     --ssh-path-to-private-key `minikube ssh-key` \
+    --ssh-password `minikube ssh-password` \
     --override-ssh-host `minikube ip` \
     --host 0.0.0.0 \
     --port 30100

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -63,16 +63,22 @@ def add_ssh_options(parser):
         help='Allow connection to hosts not present in known_hosts',
     )
     args_ssh.add_argument(
-        '--ssh-path-to-private-key',
-        default=os.environ.get("PS_PRIVATE_KEY"),
-        help='Path to ssh private key',
-    )
-    args_ssh.add_argument(
         '--override-ssh-host',
         help=(
             'If you\'d like to execute all commands on a different host '
             '(for example for minikube) you can override it here'
         )
+    )
+    ssh_options = args_ssh.add_mutually_exclusive_group()
+    ssh_options.add_argument(
+        '--ssh-path-to-private-key',
+        default=os.environ.get("PS_PRIVATE_KEY"),
+        help='Path to ssh private key',
+    )
+    ssh_options.add_argument(
+        '--ssh-password',
+        default=os.environ.get("PS_SSH_PASSWORD"),
+        help='ssh password',
     )
 
 def add_inventory_options(parser):
@@ -445,6 +451,7 @@ def main(argv):
         ssh_allow_missing_host_keys=args.ssh_allow_missing_host_keys,
         ssh_path_to_private_key=args.ssh_path_to_private_key,
         override_host=args.override_ssh_host,
+        ssh_password=args.ssh_password,
     )
     
     ##########################################################################

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -85,6 +85,7 @@ def add_ssh_options(parser):
         '--ssh-password',
         default=os.environ.get("PS_SSH_PASSWORD"),
         help='ssh password',
+    )
 
 def add_inventory_options(parser):
     # Inventory

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -24,7 +24,7 @@ class RemoteExecutor(object):
         Assumes password-less setup.
     """
 
-    PREFIX = ["bash", "-c"]
+    PREFIX = ["sh", "-c"]
 
     def __init__(self, nodes=None, user="cloud-user",
                  ssh_allow_missing_host_keys=False, ssh_path_to_private_key=None,


### PR DESCRIPTION
With the issue about https://github.com/bloomberg/powerfulseal/issues/88#issuecomment-450300933, I tried using all the validations and found that using password is also a workaround.This can also extend the use of powerfulseal.