### PR TITLE
Allow for kill command customization

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -86,6 +86,11 @@ def add_ssh_options(parser):
         default=os.environ.get("PS_SSH_PASSWORD"),
         help='ssh password',
     )
+    args_ssh.add_argument(
+        '--ssh-kill-command',
+        default=os.environ.get("PS_SSH_KILL_COMMAND", "sudo docker kill -s {signal} {container_id}"),
+        help='The command to execute on remote host to kill the {container_id}',
+    )
 
 def add_inventory_options(parser):
     # Inventory

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -469,8 +469,9 @@ def main(argv):
         override_host=args.override_ssh_host,
         ssh_password=args.ssh_password,
         use_private_ip=args.use_private_ip,
+        ssh_kill_command=args.ssh_kill_command,
     )
-    
+
     ##########################################################################
     # INTERACTIVE MODE
     ##########################################################################

--- a/powerfulseal/cli/pscmd.py
+++ b/powerfulseal/cli/pscmd.py
@@ -434,9 +434,8 @@ class PSCmd(cmd.Cmd):
             return print("Node not found")
 
         # execute docker of the pod on the node
-        cmd_template = "sudo docker kill %s"
         for container_id in pod.container_ids:
-            cmd = cmd_template % container_id.replace("docker://","")
+            cmd = self.executor.get_kill_command(container_id.replace("docker://",""))
             ans = False
             while ans not in ("y", "n"):
                 print("Will execute '%s' on %s. Continue ? [y/n]: " % (cmd, node))

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -25,10 +25,12 @@ class RemoteExecutor(object):
     """
 
     PREFIX = ["sh", "-c"]
+    DEFAULT_KILL_COMMAND = "sudo docker kill -s {signal} {container_id}"
 
     def __init__(self, nodes=None, user="cloud-user",
                  ssh_allow_missing_host_keys=False, ssh_path_to_private_key=None,
-                 ssh_password=None, override_host=None, use_private_ip=False, logger=None):
+                 ssh_password=None, ssh_kill_command=None, override_host=None,
+                 use_private_ip=False, logger=None):
         self.nodes = nodes or []
         self.user = user
         self.missing_host_key = (spur.ssh.MissingHostKey.accept
@@ -36,6 +38,7 @@ class RemoteExecutor(object):
                                  else spur.ssh.MissingHostKey.raise_error)
         self.ssh_path_to_private_key = ssh_path_to_private_key
         self.ssh_password = ssh_password
+        self.ssh_kill_command = ssh_kill_command or self.DEFAULT_KILL_COMMAND
         self.override_host = override_host
         self.use_private_ip = use_private_ip
         self.logger = logger or logging.getLogger(__name__)

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -88,3 +88,7 @@ class RemoteExecutor(object):
                 }
                 self.logger.info("Executing '%s' on %s failed with error: %s" % (cmd_full, node.name, str(e)))
         return results
+
+    def get_kill_command(self, container_id, signal="SIGKILL"):
+        """ Produces a templated command to execute """
+        return self.ssh_kill_command.format(signal=str(signal), container_id=str(container_id))

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -44,6 +44,9 @@ class RemoteExecutor(object):
         self.logger = logger or logging.getLogger(__name__)
 
     def execute(self, cmd, nodes=None, use_private_ip=None, debug=False):
+        """
+            Executes an arbitrary command, prefixed with sh -c, on each node
+        """
         nodes = nodes or self.nodes
         use_private_ip = use_private_ip or self.use_private_ip
         results = dict()

--- a/powerfulseal/policy/demo_runner.py
+++ b/powerfulseal/policy/demo_runner.py
@@ -15,8 +15,6 @@ import logging
 import random
 import time
 
-from powerfulseal.policy.pod_scenario import POD_KILL_CMD_TEMPLATE
-
 MIN_AGGRESSIVENESS = 1
 MAX_AGGRESSIVENESS = 5
 
@@ -83,7 +81,7 @@ class DemoRunner:
 
         # Format command
         container_id = random.choice(pod.container_ids)
-        cmd = POD_KILL_CMD_TEMPLATE.format(
+        cmd = self.executor.get_kill_command(
             signal="SIGTERM",
             container_id=container_id.replace("docker://", ""),
         )

--- a/powerfulseal/policy/label_runner.py
+++ b/powerfulseal/policy/label_runner.py
@@ -16,8 +16,6 @@ import random
 import time
 from datetime import datetime
 
-from powerfulseal.policy.pod_scenario import POD_KILL_CMD_TEMPLATE
-
 
 class LabelRunner:
     """
@@ -82,7 +80,7 @@ class LabelRunner:
         # Format command
         signal = "SIGKILL" if pod.labels.get("seal/force-kill", "false") == "true" else "SIGTERM"
         container_id = random.choice(pod.container_ids)
-        cmd = POD_KILL_CMD_TEMPLATE.format(
+        cmd = self.executor.get_kill_command(
             signal=signal,
             container_id=container_id.replace("docker://", ""),
         )

--- a/powerfulseal/policy/pod_scenario.py
+++ b/powerfulseal/policy/pod_scenario.py
@@ -19,8 +19,6 @@ import random
 from powerfulseal.metriccollectors.collector import POD_SOURCE
 from .scenario import Scenario
 
-POD_KILL_CMD_TEMPLATE = "sudo docker kill -s {signal} {container_id}"
-
 
 class PodScenario(Scenario):
     """ Pod scenario handler.
@@ -34,7 +32,6 @@ class PodScenario(Scenario):
         self.inventory = inventory
         self.k8s_inventory = k8s_inventory
         self.executor = executor
-        self.cmd_template = POD_KILL_CMD_TEMPLATE
 
     def match(self):
         """ Makes a union of all the pods matching any of the policy criteria.
@@ -105,7 +102,7 @@ class PodScenario(Scenario):
         force = params.get("force", True)
         signal = "SIGKILL" if force else "SIGTERM"
         container_id = random.choice(item.container_ids)
-        cmd = self.cmd_template.format(
+        cmd = self.executor.get_kill_command(
             signal=signal,
             container_id=container_id.replace("docker://",""),
         )

--- a/powerfulseal/web/server.py
+++ b/powerfulseal/web/server.py
@@ -25,7 +25,7 @@ from flask_swagger_ui import get_swaggerui_blueprint
 
 from powerfulseal.policy import PolicyRunner
 from powerfulseal.policy.node_scenario import NodeScenario
-from powerfulseal.policy.pod_scenario import POD_KILL_CMD_TEMPLATE, PodScenario
+from powerfulseal.policy.pod_scenario import PodScenario
 from powerfulseal.web.formatter import PolicyFormatter
 
 # Flask instance and routes
@@ -420,7 +420,7 @@ class ServerState:
         # Format kill command
         signal = "SIGKILL" if is_forced else "SIGTERM"
         container_id = random.choice(pod.container_ids)
-        cmd = POD_KILL_CMD_TEMPLATE.format(
+        cmd = self.executor.get_kill_command(
             signal=signal,
             container_id=container_id.replace("docker://", ""),
         )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.0.1',
+    version='2.1.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,6 +17,7 @@ from mock import MagicMock
 from powerfulseal.policy.node_scenario import NodeScenario
 from powerfulseal.policy.pod_scenario import PodScenario
 from powerfulseal.policy.scenario import Scenario
+from powerfulseal.execute import RemoteExecutor
 
 
 # Common fixtures
@@ -66,7 +67,7 @@ EXAMPLE_POD_SCHEMA = {
 def pod_scenario():
     inventory = MagicMock()
     k8s_inventory = MagicMock()
-    executor = MagicMock()
+    executor = RemoteExecutor()
     return PodScenario(
         name="test scenario",
         schema=EXAMPLE_POD_SCHEMA,


### PR DESCRIPTION
Currently, `sudo docker kill` command is hardcoded.

This PR introduces a new command line argument, `--ssh-kill-command` (still defaulting to `sudo docker kill -s {signal} {container_id}"`) via which the user can customize the docker (or other compatible binary) to be executed.