### PR TITLE
Fix #108: Update Flask dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'jsonschema>=2.6.0,<3',
         'boto3>=1.5.15,<2.0.0',
         'future>=0.16.0,<1',
-        'requests>=2.19.1,<3',
+        'requests>=2.21.0,<3',
         'prometheus_client>=0.3.0,<0.4.0',
         'flask-cors>=3.0.6,<4',
         'flask-swagger-ui>=3.18.0<4',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=read('README.md'),
     install_requires=[
         'ConfigArgParse>=0.11.0,<1',
-        'Flask>=0.12.2,<0.13',
+        'Flask>=1.0.0,<2',
         'termcolor>=1.1.0,<2',
         'openstacksdk>=0.10.0,<1',
         'spur>=0.3.20,<1',


### PR DESCRIPTION
Tracked the dependency to Flask [[0](https://github.com/pallets/flask/issues/2549)] and it has been fixed [[1](http://flask.pocoo.org/docs/1.0/changelog/)] on flask >1.0 (It was related with the JSONIFY_PRETTYPRINT_REGULAR default) so I updated the dependency and seems to solve  #108 . 
On the other side, fixing this generates the following warning:

On Python 2.7,3.4,3.5,3.7:
`.tox/py27/lib/python2.7/site-packages/requests/__init__.py:91
  /home/travis/build/dgzlopes/powerfulseal/.tox/py27/lib/python2.7/site-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.25) or chardet (3.0.4) doesn't match a supported version!
    RequestsDependencyWarning)`

Seems to come from Requests and as reflected on this issue [[2](https://github.com/kennethreitz/requests/issues/5067)] looks like they are working on solving it!


[[0](https://github.com/pallets/flask/issues/2549)] https://github.com/pallets/flask/issues/2549
[[1](http://flask.pocoo.org/docs/1.0/changelog/)] http://flask.pocoo.org/docs/1.0/changelog/
[[2](https://github.com/kennethreitz/requests/issues/5067)] https://github.com/kennethreitz/requests/issues/5067