### PR TITLE
Fix input() compatibility 

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -494,7 +494,7 @@ def main(argv):
                 print()
                 print("Ctrl-c again to quit")
             try:
-                input()
+                six.moves.input()
             except KeyboardInterrupt:
                 sys.exit(0)
         return

--- a/powerfulseal/cli/pscmd.py
+++ b/powerfulseal/cli/pscmd.py
@@ -206,7 +206,7 @@ class PSCmd(cmd.Cmd):
             answer = None
             while answer not in ("yes", "no"):
                 sys.stdout.write("Proceed ? (yes|no): ")
-                answer = input()
+                answer = six.moves.input()
             if answer == "yes":
                 print("Deleting")
                 self.driver.delete(node)


### PR DESCRIPTION
Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>

Fix compatibility between Python 2 and 3 using `six.moves.input()`. Crashed for me today on interactive mode while using Python 2.7. This solution is already used on `pscmd.py ` line 442.