### PR TITLE
Fix YAML load()

### DIFF
--- a/powerfulseal/policy/policy_runner.py
+++ b/powerfulseal/policy/policy_runner.py
@@ -36,12 +36,12 @@ class PolicyRunner():
         """ Reads the schema from the file
         """
         data = pkgutil.get_data(__name__, "ps-schema.json")
-        return yaml.load(data)
+        return yaml.safe_load(data)
 
     @classmethod
     def load_file(cls, filename):
         with open(filename, "r") as f:
-            return yaml.load(f.read())
+            return yaml.safe_load(f.read())
 
     @classmethod
     def is_policy_valid(cls, policy, schema=None):


### PR DESCRIPTION
Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>

Just one minor fix for using the safer `safe_load()` instead of `load()` for loading YAML. Some reasoning about this best practice on PyYAML docs [[0](https://pyyaml.org/wiki/PyYAMLDocumentation)] and on this OpenStack Guideline [[1](https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html#consequences)].

[[0](https://pyyaml.org/wiki/PyYAMLDocumentation)] https://pyyaml.org/wiki/PyYAMLDocumentation (Loading YAML section)
[[1](https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html#consequences)] https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html#consequences