### PR TITLE
Azure Cloud Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Embrace the inevitable failure. __Embrace The Seal__.
 
 ## Highlights
 
-- works with `OpenStack`, `AWS` and local machines
+- works with `OpenStack`, `AWS`, `Azure`, and local machines
 - speaks `Kubernetes` natively
 - interactive and autonomous, policy-driven mode
 - web interface to interact with PowerfulSeal
@@ -59,11 +59,14 @@ __PowerfulSeal__ works in several modes:
 ```sh
 $ seal interactive --help
 usage: seal interactive [-h] --kubeconfig KUBECONFIG
-                        (--openstack | --aws | --no-cloud)
+                        (--openstack | --aws | --azure | --no-cloud)
                         [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
+                        [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
+                        [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
                         (-i INVENTORY_FILE | --inventory-kubernetes)
                         [--remote-user REMOTE_USER]
                         [--ssh-allow-missing-host-keys]
+                        [--override-ssh-host OVERRIDE_SSH_HOST]
                         [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
                         [--ssh-password SSH_PASSWORD]
                         [--use-private-ip]
@@ -78,10 +81,18 @@ Kubernetes settings:
 Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
+  --azure               use Azure cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
                         file to use
+  --azure-resource-group-name AZURE_RESOURCE_GROUP_NAME
+                        optional name of the Azure VM cluster resource group.
+                        Used to determine azure-node-resource-group-name if 
+                        that is not provided.  
+  --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
+                        name of the Azure VM cluster node resource group
+                        Required when using Azure cloud provider.
 
 Inventory settings:
    -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -95,6 +106,10 @@ SSH settings:
                         the of the user for the ssh connections
   --ssh-allow-missing-host-keys
                         Allow connection to hosts not present in known_hosts
+  --override-ssh-host OVERRIDE_SSH_HOST
+                        If you'd like to execute all commands on a different
+                        host (for example for minikube) you can override it
+                        here
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
   --ssh-password SSH_PASSWORD
@@ -122,11 +137,14 @@ Autonomous reads the scenarios to execute from the policy file, and runs them:
 ```sh
 $ seal autonomous --help
 usage: seal autonomous [-h] --kubeconfig KUBECONFIG
-                       (--openstack | --aws | --no-cloud)
+                       (--openstack | --aws | --azure | --no-cloud)
                        [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
+                       [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
+                       [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
                        (-i INVENTORY_FILE | --inventory-kubernetes)
                        [--remote-user REMOTE_USER]
                        [--ssh-allow-missing-host-keys]
+                       [--override-ssh-host OVERRIDE_SSH_HOST]
                        [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
                        [--ssh-password SSH_PASSWORD]
                        [--use-private-ip]
@@ -146,10 +164,18 @@ Kubernetes settings:
 Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
+  --azure               use Azure cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
                         file to use
+  --azure-resource-group-name AZURE_RESOURCE_GROUP_NAME
+                        optional name of the Azure VM cluster resource group.
+                        Used to determine azure-node-resource-group-name if 
+                        that is not provided.  
+  --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
+                        name of the Azure VM cluster node resource group
+                        Required when using Azure cloud provider.
 
 Inventory settings:
   -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -162,6 +188,10 @@ SSH settings:
                         the of the user for the ssh connections
   --ssh-allow-missing-host-keys
                         Allow connection to hosts not present in known_hosts
+  --override-ssh-host OVERRIDE_SSH_HOST
+                        If you'd like to execute all commands on a different
+                        host (for example for minikube) you can override it
+                        here
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
   --ssh-password SSH_PASSWORD
@@ -264,10 +294,13 @@ Instructions on how to use label mode can be found in [LABELS.md](LABELS.md).
 ```sh
 $ seal label --help
 usage: seal label [-h] --kubeconfig KUBECONFIG
-                  (--openstack | --aws | --no-cloud)
+                  (--openstack | --aws | --azure | --no-cloud)
                   [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
+                  [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
+                  [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
                   (-i INVENTORY_FILE | --inventory-kubernetes)
                   [--remote-user REMOTE_USER] [--ssh-allow-missing-host-keys]
+                  [--override-ssh-host OVERRIDE_SSH_HOST]
                   [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
                   [--ssh-password SSH_PASSWORD]
                   [--use-private-ip]
@@ -288,10 +321,18 @@ Kubernetes settings:
 Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
+  --azure               use Azure cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
                         file to use
+  --azure-resource-group-name AZURE_RESOURCE_GROUP_NAME
+                        optional name of the Azure VM cluster resource group.
+                        Used to determine azure-node-resource-group-name if 
+                        that is not provided.  
+  --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
+                        name of the Azure VM cluster node resource group
+                        Required when using Azure cloud provider.
 
 Inventory settings:
   -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -304,6 +345,10 @@ SSH settings:
                         the of the user for the ssh connections
   --ssh-allow-missing-host-keys
                         Allow connection to hosts not present in known_hosts
+  --override-ssh-host OVERRIDE_SSH_HOST
+                        If you'd like to execute all commands on a different
+                        host (for example for minikube) you can override it
+                        here
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
   --ssh-password SSH_PASSWORD
@@ -346,10 +391,13 @@ Demo mode requires [Heapster](https://github.com/kubernetes/heapster). To run de
 ```sh
 $ seal demo --help
 usage: seal demo [-h] --kubeconfig KUBECONFIG
-                 (--openstack | --aws | --no-cloud)
+                 (--openstack | --aws | --azure | --no-cloud)
                  [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
+                 [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
+                 [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
                  (-i INVENTORY_FILE | --inventory-kubernetes)
                  [--remote-user REMOTE_USER] [--ssh-allow-missing-host-keys]
+                 [--override-ssh-host OVERRIDE_SSH_HOST]
                  [--ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY]
                  [--ssh-password SSH_PASSWORD]
                  [--use-private-ip]
@@ -371,10 +419,18 @@ Kubernetes settings:
 Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
+  --azure               use Azure cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
                         file to use
+  --azure-resource-group-name AZURE_RESOURCE_GROUP_NAME
+                        optional name of the Azure VM cluster resource group.
+                        Used to determine azure-node-resource-group-name if 
+                        that is not provided.  
+  --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
+                        name of the Azure VM cluster node resource group
+                        Required when using Azure cloud provider.
 
 Inventory settings:
   -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -387,6 +443,10 @@ SSH settings:
                         the of the user for the ssh connections
   --ssh-allow-missing-host-keys
                         Allow connection to hosts not present in known_hosts
+  --override-ssh-host OVERRIDE_SSH_HOST
+                        If you'd like to execute all commands on a different
+                        host (for example for minikube) you can override it
+                        here
   --ssh-path-to-private-key SSH_PATH_TO_PRIVATE_KEY
                         Path to ssh private key
   --ssh-password SSH_PASSWORD
@@ -528,6 +588,33 @@ myhost02
 myhost01
 myhost02
 ```
+
+## Cloud Provider Requirements
+
+### SSH
+
+In all cases, the SSH Keys must be set up for SSH Client access of the nodes.  
+
+### Azure
+
+The credentials to connect to Azure may be specified in one of two ways:
+
+1. Supply the full path to an Azure credentials file in the environment variable `AZURE_AUTH_LOCATION`.  
+This is the easiest method.  The credentials file can be generated via `az aks get-credentials -n <cluster name> -g <resouce group> -a -f <desitnation credentials file>`
+2. Supply the individual credentials in the environment variables: `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`
+
+### AWS
+
+The credentials to connect to AWS are specified the same as for the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+
+### OpenStack
+
+TBD
+
+### Bare Metal
+
+TBD
+
 
 ## Testing
 

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -31,7 +31,7 @@ from powerfulseal.policy.label_runner import LabelRunner
 from powerfulseal.web.server import ServerState, start_server, ServerStateLogHandler
 from ..node import NodeInventory
 from ..node.inventory import read_inventory_file_to_dict
-from ..clouddrivers import OpenStackDriver, AWSDriver, NoCloudDriver
+from ..clouddrivers import OpenStackDriver, AWSDriver, NoCloudDriver, AzureDriver
 from ..execute import RemoteExecutor
 from ..k8s import K8sClient, K8sInventory
 from .pscmd import PSCmd
@@ -121,6 +121,11 @@ def add_cloud_options(parser):
         action='store_true',
         help="use AWS cloud provider",
     )
+    cloud_options.add_argument('--azure',
+        default=os.environ.get("AZURE_CLOUD"),
+        action='store_true',
+        help="use Azure cloud provider",
+    )
     cloud_options.add_argument('--no-cloud',
         default=os.environ.get("NO_CLOUD"),
         action='store_true',
@@ -130,6 +135,14 @@ def add_cloud_options(parser):
     args.add_argument('--openstack-cloud-name',
         default=os.environ.get("OPENSTACK_CLOUD_NAME"),
         help="optional name of the open stack cloud from your config file to use",
+    )
+    args.add_argument('--azure-resource-group-name',
+        default=os.environ.get("AZURE_RESORUCE_GROUP_NAME"),
+        help="optional name of the Azure vm cluster resource group. Used to determine azure-node-resource-group-name.",
+    )
+    args.add_argument('--azure-node-resource-group-name',
+        default=os.environ.get("AZURE_NODE_RESORUCE_GROUP_NAME"),
+        help="name of the Azure vm cluster node resource group",
     )
 
 def add_namespace_options(parser):
@@ -433,6 +446,12 @@ def main(argv):
     elif args.aws:
         logger.info("Building AWS driver")
         driver = AWSDriver()
+    elif args.azure:
+        logger.info("Building Azure driver")
+        driver = AzureDriver(
+            cluster_rg_name=args.azure_resource_group_name,
+            cluster_node_rg_name=args.azure_node_resource_group_name,
+        )
     else:
         logger.info("No driver - some functionality disabled")
         driver = NoCloudDriver()

--- a/powerfulseal/clouddrivers/__init__.py
+++ b/powerfulseal/clouddrivers/__init__.py
@@ -16,4 +16,5 @@
 from .driver import AbstractDriver
 from .open_stack_driver import OpenStackDriver
 from .aws_driver import AWSDriver
+from .azure_driver import AzureDriver
 from .no_cloud_driver import NoCloudDriver

--- a/powerfulseal/clouddrivers/azure_driver.py
+++ b/powerfulseal/clouddrivers/azure_driver.py
@@ -1,0 +1,193 @@
+import os
+import sys
+import logging
+from . import AbstractDriver
+from ..node import Node, NodeState
+
+from azure.common.client_factory import get_client_from_auth_file
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.mgmt.resource import ResourceManagementClient
+from azure.mgmt.network import NetworkManagementClient
+from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.compute.models import DiskCreateOption
+
+def create_connection_from_config():
+    """ Creates a new Azure api connection """
+    resource_client = None
+    compute_client = None
+    network_client = None
+    try:
+        cred_file_loc=os.environ['AZURE_AUTH_LOCATION']
+    except KeyError:
+        try:
+            subscription_id = os.environ['AZURE_SUBSCRIPTION_ID']
+            credentials = ServicePrincipalCredentials(
+                client_id=os.environ['AZURE_CLIENT_ID'],
+                secret=os.environ['AZURE_CLIENT_SECRET'],
+                tenant=os.environ['AZURE_TENANT_ID']
+            )
+        except KeyError:
+            sys.exit("No Azure Connection Defined")
+        else:
+           resource_client = ResourceManagementClient(credentials, subscription_id)
+           compute_client = ComputeManagementClient(credentials, subscription_id)
+           network_client = NetworkManagementClient(credentials, subscription_id)
+    else:
+        resource_client = get_client_from_auth_file(ResourceManagementClient)
+        compute_client = get_client_from_auth_file(ComputeManagementClient)
+        network_client = get_client_from_auth_file(NetworkManagementClient)
+
+    return resource_client, compute_client, network_client
+
+def get_all_ips(instance, network_client):
+    """ Returns the private and public ip addresses of an Azure instances
+    """
+    output = []
+    for interface in instance.network_profile.network_interfaces:
+        if_name=" ".join(interface.id.split('/')[-1:])
+        rg="".join(interface.id.split('/')[4])
+
+        try:
+            thing=network_client.network_interfaces.get(rg, if_name).ip_configurations
+            for x in thing:
+                private_ip=x.private_ip_address
+                public_ip=None
+                """print('\nifdata: ',rg,if_name,x.private_ip_address,x.public_ip_address)"""
+                """ Have to extract public IP from public IP class structure...if present """
+                if x.public_ip_address is not None:
+                    public_ip_id=x.public_ip_address.id
+                    public_ip_name=" ".join(public_ip_id.split('/')[-1:])
+                    try:
+                        public_ip_return = network_client.public_ip_addresses.get(rg, public_ip_name)
+                        public_ip=public_ip_return.ip_address
+                    except:
+                        """ Ignore the exception.  return no additional values """
+                        pass
+
+                temp_pair = (private_ip, public_ip)
+                output.append(temp_pair)
+
+        except Exception as e:
+            """ Ignore the exception.  return no additional values """
+            pass
+
+    return output
+
+def server_state(compute_client, server):
+    ret_state=NodeState.UNKNOWN
+    try:
+        tmp_rg="".join(server.id.split('/')[4])
+        instance_view = compute_client.virtual_machines.instance_view(resource_group_name=tmp_rg, vm_name=server.name)
+        status_code_operating = ",".join([s.code for s in instance_view.statuses]) or 'Unknown'
+        if status_code_operating == 'ProvisioningState/succeeded,PowerState/running':
+            ret_state=NodeState.UP
+        elif status_code_operating != 'Unknown':
+            ret_state=NodeState.DOWN
+    except:
+        """ignore"""
+        pass
+
+    return ret_state
+
+def create_node_from_server(compute_client,server,int_ip, ext_ip):
+    return Node(
+        id=server.id,
+        ip=int_ip,
+        extIp=ext_ip or int_ip,
+        az=server.location,
+        name=server.name,
+        state=server_state(compute_client,server)
+    )
+
+class AzureDriver(AbstractDriver):
+    """
+        Concrete implementation of the Azure cloud driver.
+    """
+
+    def __init__(self, cluster_rg_name=None, cluster_node_rg_name=None, cloud=None, conn=None, logger=None):
+        self.logger = logger or logging.getLogger(__name__)
+        self.resource_client, self.compute_client, self.network_client = create_connection_from_config()
+        self.remote_servers = []
+        self.cluster_rg = cluster_rg_name
+        self.cluster_node_rg = cluster_node_rg_name
+
+    def getResourceGroups(self):
+        """ Find nodeResourceGroup for the cluster.
+            This can be determined by finding the resource groups that are managed_by 
+            the cluater resource group ID
+        """
+        self.logger.info("++ Azure cluster_rg: %s", self.cluster_rg)
+        self.logger.info("++ Azure cluster_node_rg: %s", self.cluster_node_rg)
+
+        if self.cluster_node_rg is None:
+            if self.cluster_rg is not None:
+                """ get the nodeResouceGroup for the cluster ResourceGroup """
+                crg = self.resource_client.resource_groups.get(self.cluster_rg)
+                """ get resource groups managedBy the returned id e.g. crg.id == <>.managed_by """
+                """ NOTE: azure python API resource selection filter does not appear to select correctly,
+                So, query all resources and process here instead.
+                """
+                rgl = self.resource_client.resource_groups.list(None)
+                for trg in rgl:
+                    if trg.managed_by is not None:
+                        if trg.managed_by.startswith(crg.id):
+                            self.cluster_node_rg = trg.name
+                            self.logger.info("++ Azure cluster_node_rg set to: %s", self.cluster_node_rg)
+                            break
+            else:
+                """ Don't have the cluster resource group.
+                    NOTE: it should be possible to determine it from the kubernetes cluster name.
+                    however, the current (4/17/2019), python azure API doesn't support
+                    querying aks by kubernetes cluster name.
+                """
+                self.logger.warning("Azure Cluster Resource Group is not specified.  Please specify as an argument.")
+
+
+    def sync(self):
+        """ Downloads a fresh set of nodes form the API.
+        """
+        self.logger.info("Synchronizing remote nodes")
+        """only get the resource group for the current cluster 
+        """
+        self.getResourceGroups()
+        self.remote_servers = []
+        if self.cluster_node_rg is not None:
+            self.remote_servers = list(self.compute_client.virtual_machines.list(self.cluster_node_rg))
+        else:
+            self.logger.warning("No Azure cluster node resource group was found, the node list may be incorrect.")
+            self.remote_servers = list(self.compute_client.virtual_machines.list_all())
+
+        self.logger.info("Fetched %s remote servers" % len(self.remote_servers))
+
+    def get_by_ip(self, ip):
+        """ Retrieve an instance of Node by its IP.
+        """
+        for server in self.remote_servers:
+            addresses = get_all_ips(server, self.network_client)
+            if not addresses:
+                self.logger.warning("No ip addresses found: %s", server.__dict__)
+            else:
+                """ returns first node """
+                for addr in addresses:
+                    if addr[0] == ip or addr[1] == ip:
+                        new_node=create_node_from_server(compute_client=self.compute_client, server=server, int_ip=addr[0], ext_ip=addr[1])
+                        return new_node
+        return None
+
+    def stop(self, node):
+        """ Stop a Node.
+        """
+        async_vm_start = self.compute_client.virtual_machines.power_off(self.cluster_node_rg, node.name)
+        async_vm_start.wait()
+
+    def start(self, node):
+        """ Start a Node.
+        """
+        async_vm_restart = self.compute_client.virtual_machines.start(self.cluster_node_rg, node.name)
+        async_vm_restart.wait()
+
+    def delete(self, node):
+        """ Delete a Node permanently.
+        """
+        async_vm_delete = self.compute_client.virtual_machines.delete(self.cluster_node_rg, node.name)
+        async_vm_delete.wait()

--- a/powerfulseal/execute/remote_executor.py
+++ b/powerfulseal/execute/remote_executor.py
@@ -78,8 +78,8 @@ class RemoteExecutor(object):
                     output = shell.run(cmd_full)
                     results[hostip] = {
                         "ret_code": output.return_code,
-                        "stdout": output.output.decode(),
-                        "stderr": output.stderr_output.decode(),
+                        "stdout": output.output.decode('utf-8'),
+                        "stderr": output.stderr_output.decode('utf-8'),
                     }
             except Exception as e:
                 results[hostip] = {

--- a/powerfulseal/node/node_inventory.py
+++ b/powerfulseal/node/node_inventory.py
@@ -94,6 +94,7 @@ class NodeInventory():
         """
             Update the nodes based on the values returned from the driver
         """
+        self.logger.info("Sync Nodes")
         driver = driver or self.driver
         driver.sync()
         counter = 0
@@ -120,9 +121,9 @@ class NodeInventory():
                     try:
                         # validate that this is an IP or not
                         ipaddress.ip_address(ip)
-                        self.logger.info("Couldn't match IP to cloud node: %s", ip)
+                        self.logger.debug("Couldn't match IP to any cloud node: %s", ip)
                     except:
-                        self.logger.debug("Couldn't match to cloud node: %s", ip)
+                        self.logger.debug("Couldn't match to any cloud node: %s", ip)
                     continue
 
                 self.nodes_by_id[node.id] = node

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.1.0',
+    version='2.2.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,15 @@ setup(
         'PyYAML>=3.12,<4',
         'jsonschema>=2.6.0,<3',
         'boto3>=1.5.15,<2.0.0',
+        'azure>=4.0.0,<5.0.0',
         'future>=0.16.0,<1',
         'requests>=2.19.1,<3',
         'prometheus_client>=0.3.0,<0.4.0',
         'flask-cors>=3.0.6,<4',
         'flask-swagger-ui>=3.18.0<4',
         'coloredlogs>=10.0.0,<11.0.0',
-        'six>=1.12.0,<2'
+        'six>=1.12.0,<2',
+        'paramiko>=2.5.0,<3'
     ],
     extras_require={
         'testing': [

--- a/tests/clouddrivers/test_azure_driver.py
+++ b/tests/clouddrivers/test_azure_driver.py
@@ -1,0 +1,128 @@
+import pytest
+from mock import patch, MagicMock
+from powerfulseal.clouddrivers import azure_driver
+from powerfulseal.node import Node, NodeState
+
+PRIVATE_IPS = ['198.168.1.1', '198.168.1.2', '198.168.1.3']
+PUBLIC_IPS = ['31.31.31.31', '41.41.41.41']
+INVALID_IP = '198.168.3.1'
+
+class VMPublicIP():
+    def __init__(self,rg,name,ip):
+        self.id='/subscriptions/a32253aa-111111/resourceGroups/'+rg+'/providers/Microsoft.Network/publicIPAddresses/'+name
+        self.rg=rg
+        self.name=name
+        self.ip_address=ip
+
+class VMPublicIPs():
+    def __init__(self,rg,name,ip):
+        self.theIP = VMPublicIP(rg,"bogusIP2","0.0.0.0")
+        if name is not None:
+            self.theIP=VMPublicIP(rg,name,ip)
+
+    def get(self,rg,ipname):
+        if rg == self.theIP.rg and ipname == self.theIP.name:
+            return self.theIP
+        return VMPublicIP(rg,"bogusIP2","0.0.0.0")
+
+class VMIP():
+    def __init__(self,priv_ip, rg, pub_ip_name, pub_ip):
+        self.private_ip_address=priv_ip
+        self.public_ip_address=None
+        if pub_ip_name is not None:
+            self.public_ip_address=VMPublicIP(rg, pub_ip_name,pub_ip)
+
+class VMIPConfig():
+    def __init__(self,rg,ifname,priv_ip,pub_ip_name, pub_ip):
+        self.ip_configurations=[VMIP(priv_ip, rg, pub_ip_name, pub_ip)]
+        self.rg = rg
+        self.name = ifname
+
+class VMNetworkInterface():
+    def __init__(self, rg, ifname, priv_ip, pub_ip_name, pub_ip):
+        self.theif= VMIPConfig(rg, ifname, priv_ip, pub_ip_name, pub_ip)
+
+    def get(self,rg, name):
+        if rg== self.theif.rg and name == self.theif.name:
+            return self.theif
+        return  VMIPConfig("foo", "bar", "10.10.10.10`", "bogusIp", "20.20.20.20")
+
+class VMNetworkClient():
+    def __init__(self, rg, ifname, priv_ip, pub_ip_name, pub_ip):
+        self.network_interfaces=VMNetworkInterface(rg, ifname, priv_ip, pub_ip_name, pub_ip)
+        self.public_ip_addresses=VMPublicIPs(rg, pub_ip_name, pub_ip)
+
+class VMNetID():
+    def __init__(self,rg, ifname):
+        self.id='/subscriptions/a32253aa-111111/resourceGroups/'+rg+'/providers/Microsoft.Network/networkInterfaces/'+ifname 
+
+class VMNetworkProfile():
+    def __init__(self, rg, ifname):
+        self.network_interfaces=[VMNetID(rg, ifname)]
+
+class VMServerStatus():
+    def __init__(self,state):
+        self.code = state
+
+class  VMServerMachine():
+    def __init__(self, id, state):
+        self.id = id
+        self.statuses = [ VMServerStatus('ProvisioningState/succeeded'),  VMServerStatus(state) ]
+
+    def instance_view(self,resource_group_name,vm_name):
+        return self
+
+class VMCompute():
+    def __init__(self,id, state):
+        self.virtual_machines = VMServerMachine(id, state)
+
+class VMInstance():
+    def __init__(self, id, name, zone, state, rg, ifname, priv_ip, pub_ip_name, pub_ip):
+        self.id = id
+        self.network_profile=VMNetworkProfile(rg, ifname)
+        self.location = zone
+        self.name = name
+        self.state = state
+        self.network_stuff = VMNetworkClient(rg, ifname, priv_ip, pub_ip_name, pub_ip)
+        self.compute_stuff = VMCompute(id, state)
+
+   
+@pytest.fixture
+def vm_instances():
+    return [
+        VMInstance(id="/subscriptions/a32253aa-111111/resourceGroups/MC_test-rg-2_westus/providers/Microsoft.Compute/virtualMachines/aks-workers-67219403-0", name="aks-workers-67219403-0", zone="westus", state="PowerState/running", rg="MC_test-rg-2_westus", ifname="two",priv_ip="198.168.1.1", pub_ip_name="publicIp01",pub_ip="31.31.31.31"),
+        VMInstance(id="/subscriptions/a32253aa-111111/resourceGroups/MC_test-rg-2_westus/providers/Microsoft.Compute/virtualMachines/aks-workers-67219403-1", name="aks-workers-67219403-1", zone="westus", state="PowerState/stopped", rg="MC_test-rg-2_westus", ifname="four",priv_ip="198.168.1.2", pub_ip_name="publicIp02", pub_ip="41.41.41.41"),
+        VMInstance(id="/subscriptions/a32253aa-111111/resourceGroups/MC_test-rg-2_westus/providers/Microsoft.Compute/virtualMachines/aks-workers-67219403-2", name="aks-workers-67219403-2", zone="westus", state="UNKNOWN", rg="MC_test-rg-2_westus", ifname="six",priv_ip="198.168.1.3", pub_ip_name=None, pub_ip=None),
+]
+
+
+@patch('powerfulseal.clouddrivers.azure_driver.create_connection_from_config', return_value=(None, None, None))
+def test_get_by_ip_private_ip_nodes(create_connection_from_config, vm_instances):
+    driver = azure_driver.AzureDriver()
+    driver.remote_servers = vm_instances
+    node_index = 0
+    driver.network_client = vm_instances[node_index].network_stuff
+    driver.compute_client =  vm_instances[node_index].compute_stuff
+    nodes = driver.get_by_ip(PRIVATE_IPS[node_index])
+    assert vm_instances[node_index].id is nodes.id
+    assert vm_instances[node_index].location is nodes.az
+    assert vm_instances[node_index].network_stuff.network_interfaces.theif.ip_configurations[0].private_ip_address == nodes.ip
+
+@patch('powerfulseal.clouddrivers.azure_driver.create_connection_from_config', return_value=(None, None, None))
+def test_get_by_ip_public_ip_nodes(create_connection_from_config, vm_instances):
+    driver = azure_driver.AzureDriver()
+    driver.remote_servers = vm_instances
+    node_index = 1
+    driver.network_client = vm_instances[node_index].network_stuff
+    nodes = driver.get_by_ip(PUBLIC_IPS[node_index])
+    assert vm_instances[node_index].id is nodes.id
+    assert vm_instances[node_index].location is nodes.az
+    assert vm_instances[node_index].network_stuff.network_interfaces.theif.ip_configurations[0].public_ip_address.ip_address== nodes.extIp
+
+@patch('powerfulseal.clouddrivers.azure_driver.create_connection_from_config', return_value=(None, None, None))
+def test_get_by_ip_no_nodes(create_connection_from_config, vm_instances):
+    driver = azure_driver.AzureDriver()
+    driver.remote_servers = vm_instances
+    driver.network_client = vm_instances[2].network_stuff
+    nodes = driver.get_by_ip(INVALID_IP)
+    assert nodes is None


### PR DESCRIPTION
Adds Azure Cloud Driver.

Note: paramiko library changes are required for communication with Azure nodes.  
There is an in-flight PR: https://github.com/paramiko/paramiko/pull/1233.  A user will have to create their own paramiko lib with those changes to be able to use this driver.

Explicit utf-8 encoding was needed to process the strings returned from Azure Docker commands.  This should be ok with all other cloud providers.

New section in overall README for cloud provider specifics added.  This should be filled out more in another PR.

Related issue: https://github.com/bloomberg/powerfulseal/issues/101