### PR TITLE
Add GCP driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Embrace the inevitable failure. __Embrace The Seal__.
 
 ## Highlights
 
-- works with `OpenStack`, `AWS`, `Azure`, and local machines
+- works with `OpenStack`, `AWS`, `Azure`, `GCP` and local machines
 - speaks `Kubernetes` natively
 - interactive and autonomous, policy-driven mode
 - web interface to interact with PowerfulSeal
@@ -50,7 +50,7 @@ __PowerfulSeal__ works in several modes:
 
 - __Label__ mode allows you to specify which pods to kill with a small number of options by adding `seal/` labels to pods. This is a more imperative alternative to autonomous mode.  
 
-- __Demo__ mode allows you to point the Seal at a cluster and a `heapster` server and let it try to figure out what to kill based on the resource utilisation.
+- __Demo__ mode allows you to point the Seal at a cluster and a `heapster` server and let it try to figure out what to kill based on the resource utilization.
 
 ## Modes of operation
 
@@ -59,10 +59,11 @@ __PowerfulSeal__ works in several modes:
 ```sh
 $ seal interactive --help
 usage: seal interactive [-h] --kubeconfig KUBECONFIG
-                        (--openstack | --aws | --azure | --no-cloud)
+                        (--openstack | --aws | --azure | --gcp |--no-cloud)
                         [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
                         [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
                         [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
+                        [--gcp-config-file GCP_CONFIG_FILE]
                         (-i INVENTORY_FILE | --inventory-kubernetes)
                         [--remote-user REMOTE_USER]
                         [--ssh-allow-missing-host-keys]
@@ -82,6 +83,7 @@ Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
   --azure               use Azure cloud provider
+  --gcp                 use GCP cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
@@ -93,6 +95,9 @@ Cloud settings:
   --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
                         name of the Azure VM cluster node resource group
                         Required when using Azure cloud provider.
+  --gcp-config-file GCP_CONFIG_FILE
+                        name of the gcloud config file (in json) to use
+                        instead of the default one
 
 Inventory settings:
    -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -137,10 +142,11 @@ Autonomous reads the scenarios to execute from the policy file, and runs them:
 ```sh
 $ seal autonomous --help
 usage: seal autonomous [-h] --kubeconfig KUBECONFIG
-                       (--openstack | --aws | --azure | --no-cloud)
+                       (--openstack | --aws | --azure | --gcp |--no-cloud)
                        [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
                        [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
                        [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
+                       [--gcp-config-file GCP_CONFIG_FILE]
                        (-i INVENTORY_FILE | --inventory-kubernetes)
                        [--remote-user REMOTE_USER]
                        [--ssh-allow-missing-host-keys]
@@ -165,6 +171,7 @@ Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
   --azure               use Azure cloud provider
+  --gcp                 use GCP cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
@@ -176,6 +183,9 @@ Cloud settings:
   --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
                         name of the Azure VM cluster node resource group
                         Required when using Azure cloud provider.
+  --gcp-config-file GCP_CONFIG_FILE
+                        name of the gcloud config file (in json) to use
+                        instead of the default one
 
 Inventory settings:
   -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -294,10 +304,11 @@ Instructions on how to use label mode can be found in [LABELS.md](LABELS.md).
 ```sh
 $ seal label --help
 usage: seal label [-h] --kubeconfig KUBECONFIG
-                  (--openstack | --aws | --azure | --no-cloud)
+                  (--openstack | --aws | --azure | --gcp |--no-cloud)
                   [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
                   [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
                   [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
+                  [--gcp-config-file GCP_CONFIG_FILE]
                   (-i INVENTORY_FILE | --inventory-kubernetes)
                   [--remote-user REMOTE_USER] [--ssh-allow-missing-host-keys]
                   [--override-ssh-host OVERRIDE_SSH_HOST]
@@ -322,6 +333,7 @@ Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
   --azure               use Azure cloud provider
+  --gcp                 use GCP cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
@@ -333,6 +345,9 @@ Cloud settings:
   --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
                         name of the Azure VM cluster node resource group
                         Required when using Azure cloud provider.
+  --gcp-config-file GCP_CONFIG_FILE
+                        name of the gcloud config file (in json) to use
+                        instead of the default one
 
 Inventory settings:
   -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -391,10 +406,11 @@ Demo mode requires [Heapster](https://github.com/kubernetes/heapster). To run de
 ```sh
 $ seal demo --help
 usage: seal demo [-h] --kubeconfig KUBECONFIG
-                 (--openstack | --aws | --azure | --no-cloud)
+                 (--openstack | --aws | --azure | --gcp |--no-cloud)
                  [--openstack-cloud-name OPENSTACK_CLOUD_NAME]
                  [--azure-resource-group-name AZURE_RESOURCE_GROUP_NAME]
                  [--azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME]
+                 [--gcp-config-file GCP_CONFIG_FILE]
                  (-i INVENTORY_FILE | --inventory-kubernetes)
                  [--remote-user REMOTE_USER] [--ssh-allow-missing-host-keys]
                  [--override-ssh-host OVERRIDE_SSH_HOST]
@@ -420,6 +436,7 @@ Cloud settings:
   --openstack           use OpenStack cloud provider
   --aws                 use AWS cloud provider
   --azure               use Azure cloud provider
+  --gcp                 use GCP cloud provider
   --no-cloud            don't use cloud provider
   --openstack-cloud-name OPENSTACK_CLOUD_NAME
                         optional name of the open stack cloud from your config
@@ -431,6 +448,9 @@ Cloud settings:
   --azure-node-resource-group-name AZURE_NODE_RESOURCE_GROUP_NAME
                         name of the Azure VM cluster node resource group
                         Required when using Azure cloud provider.
+  --gcp-config-file GCP_CONFIG_FILE
+                        name of the gcloud config file (in json) to use
+                        instead of the default one
 
 Inventory settings:
   -i INVENTORY_FILE, --inventory-file INVENTORY_FILE
@@ -595,12 +615,15 @@ myhost02
 
 In all cases, the SSH Keys must be set up for SSH Client access of the nodes.  
 
+> Note: With GCP, running ```gcloud compute config-ssh``` makes SSHing to node instances easier by adding an alias for each instance to the user SSH configuration (~/.ssh/config) file and then being able to use the generated file with ```--ssh-path-to-private-key``` argument.
+
+
 ### Azure
 
 The credentials to connect to Azure may be specified in one of two ways:
 
 1. Supply the full path to an Azure credentials file in the environment variable `AZURE_AUTH_LOCATION`.  
-This is the easiest method.  The credentials file can be generated via `az aks get-credentials -n <cluster name> -g <resouce group> -a -f <desitnation credentials file>`
+This is the easiest method.  The credentials file can be generated via `az aks get-credentials -n <cluster name> -g <resource group> -a -f <destination credentials file>`
 2. Supply the individual credentials in the environment variables: `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`
 
 ### AWS
@@ -614,6 +637,23 @@ TBD
 ### Bare Metal
 
 TBD
+
+### GCP
+>Google Cloud SDK and kubectl are required
+
+The GCP cloud driver supports managed (GKE) and custom Kubernetes clusters running on top of Google Cloud Compute.
+
+For setting up ```PowerfulSeal```, the first step is configuring gcloud SDK (as ```PowerfulSeal``` will work with your configured [project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) and [region](https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region)) and pointing kubectl to your cluster. Both can be configured easily following [this](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl) tutorial (For GKE!). In case you don't want to use the default project/region of gcloud SDK, you can point ```PowerfulSeal``` to the correct one (in json) with ```--gcp-config-file``` argument.
+
+For being able to run node related commands, credentials have to be specified in one of these [ways](https://cloud.google.com/docs/authentication/):
+
+1. Service account (Recommended): a Google account that is associated with your GCP project, as opposed to a specific user. ```PowerfulSeal``` uses the environment variable and is pretty straightforward to set up using [this](https://cloud.google.com/docs/authentication/getting-started) tutorial.
+2. User account: Not recommended as you can reach easily reach a "quota exceeded" or "API not enabled" error. ```PowerfulSeal``` uses auto-discovery and to get it working just follow [this](https://cloud.google.com/docs/authentication/end-user).
+
+Having configuration ready and ssh connection to the node instances working, you can start playing with ```PowerfulSeal``` with this example:
+```powerfulseal interactive --kubeconfig ~/.kube/config --gcp --inventory-kubernetes --ssh-allow-missing-host-keys --ssh-path-to-private-key ~/.ssh/google_compute_engine --remote-user myuser```
+
+> Note: In case of running inside Pyenv and getting ```python2 command not found``` error when running gcloud (and you want to run ```PowerfulSeal``` with Python 3+), [this](https://github.com/pyenv/pyenv/issues/1159#issuecomment-453906182) might be useful, as gcloud requires Python2.
 
 
 ## Testing

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -32,7 +32,7 @@ from powerfulseal.policy.label_runner import LabelRunner
 from powerfulseal.web.server import ServerState, start_server, ServerStateLogHandler
 from ..node import NodeInventory
 from ..node.inventory import read_inventory_file_to_dict
-from ..clouddrivers import OpenStackDriver, AWSDriver, NoCloudDriver, AzureDriver
+from ..clouddrivers import OpenStackDriver, AWSDriver, NoCloudDriver, AzureDriver, GCPDriver
 from ..execute import RemoteExecutor
 from ..k8s import K8sClient, K8sInventory
 from .pscmd import PSCmd
@@ -127,6 +127,11 @@ def add_cloud_options(parser):
         action='store_true',
         help="use Azure cloud provider",
     )
+    cloud_options.add_argument('--gcp',
+        default=os.environ.get("GCP_CLOUD"),
+        action='store_true',
+        help="use GCP cloud provider",
+    )
     cloud_options.add_argument('--no-cloud',
         default=os.environ.get("NO_CLOUD"),
         action='store_true',
@@ -144,6 +149,10 @@ def add_cloud_options(parser):
     args.add_argument('--azure-node-resource-group-name',
         default=os.environ.get("AZURE_NODE_RESORUCE_GROUP_NAME"),
         help="name of the Azure vm cluster node resource group",
+    )
+    args.add_argument('--gcp-config-file',
+        default=os.environ.get("GCP_CONFIG_FILE"),
+        help="name of the gcloud config file (in json) to use instead of the default one",
     )
 
 def add_namespace_options(parser):
@@ -459,6 +468,9 @@ def main(argv):
             cluster_rg_name=args.azure_resource_group_name,
             cluster_node_rg_name=args.azure_node_resource_group_name,
         )
+    elif args.gcp:
+        logger.info("Building GCP driver")
+        driver = GCPDriver(config=args.gcp_config_file)
     else:
         logger.info("No driver - some functionality disabled")
         driver = NoCloudDriver()

--- a/powerfulseal/clouddrivers/__init__.py
+++ b/powerfulseal/clouddrivers/__init__.py
@@ -18,3 +18,4 @@ from .open_stack_driver import OpenStackDriver
 from .aws_driver import AWSDriver
 from .azure_driver import AzureDriver
 from .no_cloud_driver import NoCloudDriver
+from .gcp_driver import GCPDriver

--- a/powerfulseal/clouddrivers/gcp_driver.py
+++ b/powerfulseal/clouddrivers/gcp_driver.py
@@ -1,0 +1,184 @@
+import json
+import logging
+import subprocess
+import sys
+import time
+
+import googleapiclient.discovery
+from oauth2client.client import GoogleCredentials
+from oauth2client.service_account import ServiceAccountCredentials
+from six.moves import input
+
+from . import AbstractDriver
+from ..node import Node
+from ..node import NodeState
+
+
+def create_connection_from_config():
+    """ Returns Google API client for Compute. It detects credentials for Service accounts and User accounts.
+    """
+    credentials = ServiceAccountCredentials.get_application_default()
+    return googleapiclient.discovery.build(
+        'compute', 'v1', credentials=credentials)
+
+
+def get_all_ips(instance):
+    """ Returns the public and private ip addresses of an GCP Compute instance
+    """
+    ip_list = []
+
+    # TODO: Sometimes Compute instances lose the Public IP, so this is a
+    # temporal workaround
+    try:
+        ip_list.append(instance["networkInterfaces"][0]
+                       ["accessConfigs"][0]["natIP"])  # Public
+    except ValueError:
+        pass
+
+    ip_list.append(instance["networkInterfaces"][0]["networkIP"])  # Private
+    return ip_list
+
+
+# https://cloud.google.com/compute/docs/instances/instance-life-cycle
+MAPPING_STATES_STATUS = {
+    "RUNNING": NodeState.UP,
+    "STOPPED": NodeState.DOWN,
+    "TERMINATED": NodeState.DOWN,
+}
+
+
+def server_status_to_state(status):
+    return MAPPING_STATES_STATUS.get(status.upper(), NodeState.UNKNOWN)
+
+
+def create_node_from_server(server):
+    """ Translate GCP Compute Instance representation into a Node object.
+    """
+    # TODO: Sometimes Compute instances lose the Public IP, so this is a
+    # temporal workaround
+    try:
+        public_ip = server["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
+    except ValueError:
+        public_ip = 'None'
+
+    return Node(
+        id=server['id'],
+        ip=server["networkInterfaces"][0]["networkIP"],
+        extIp=public_ip,
+        az=server['zone'].rsplit('/', 1)[1],
+        name=server['name'],
+        state=server_status_to_state(server['status']),
+    )
+
+
+def get_zones_of_region(compute, region, project):
+    """ Returns the name of the zones inside a region.
+    """
+    list_of_zones = []
+
+    request = compute.zones().list(project=project)
+    while request is not None:
+        response = request.execute()
+
+        for zone in response['items']:
+            # Check if the zone is inside our region
+            if region in zone['description']:
+                list_of_zones.append(zone['description'])
+
+        request = compute.zones().list_next(
+            previous_request=request, previous_response=response)
+    return list_of_zones
+
+def list_instances(compute, project, zone):
+    """ List Compute instances inside a zone.
+    """
+    result = compute.instances().list(project=project, zone=zone).execute()
+    return result['items'] if 'items' in result else None
+
+
+def read_default_config():
+    """ Returns default configuration in json from Google Cloud SDK
+    """
+    result = subprocess.Popen(
+        ['gcloud', 'config', 'list', "--format='json'"], stdout=subprocess.PIPE)
+    out = result.stdout.read()
+    out_json = json.loads(out)
+    return out_json
+
+
+class GCPDriver(AbstractDriver):
+    """
+        Concrete implementation of the GCP cloud driver.
+    """
+
+    def __init__(self, cloud=None, conn=None, logger=None, config=None):
+        self.logger = logger or logging.getLogger(__name__)
+        self.conn = create_connection_from_config()
+        self.remote_servers = []
+        try:
+            if not config:
+                default_config = read_default_config()
+            else:
+                default_config = json.loads(config)
+            self.logger.info(
+                "Using Default gcloud config with project: %s and region: %s",
+                default_config['core']['project'],
+                default_config['compute']['region'])
+            self.region = default_config['compute']['region']
+            self.project = default_config['core']['project']
+        except Exception as ex:
+            self.logger.error("gcloud config file isn't valid")
+            self.logger.info("Exiting")
+            sys.exit(0)
+
+    def sync(self):
+        """ Downloads a fresh set of nodes from the API.
+        """
+        self.logger.info("Synchronizing remote nodes")
+        self.remote_servers = []
+        self.zones = get_zones_of_region(self.conn, self.region, self.project)
+        if self.zones is not None:
+            for zone in self.zones:
+                instances = list_instances(self.conn, self.project, zone)
+                if instances is not None:
+                    for instance in instances:
+                        self.remote_servers.append(instance)
+        self.logger.info("Fetched %s remote servers" %
+                         len(self.remote_servers))
+
+    def get_by_ip(self, ip):
+        """ Retrieve an instance of Node by its IP.
+        """
+        for server in self.remote_servers:
+            addresses = get_all_ips(server)
+            if not addresses:
+                self.logger.warning("No ip addresses found: %s", server)
+            else:
+                for addr in addresses:
+                    if addr == ip:
+                        return create_node_from_server(server)
+        return None
+
+    def stop(self, node):
+        """ Stop a Node.
+        """
+        self.conn.instances().stop(
+            project=self.project,
+            zone=node.az,
+            instance=node.name).execute()
+
+    def start(self, node):
+        """ Start a Node.
+        """
+        self.conn.instances().start(
+            project=self.project,
+            zone=node.az,
+            instance=node.name).execute()
+
+    def delete(self, node):
+        """ Delete a Node permanently.
+        """
+        self.conn.instances().delete(
+            project=self.project,
+            zone=node.az,
+            instance=node.name).execute()

--- a/powerfulseal/clouddrivers/gcp_driver.py
+++ b/powerfulseal/clouddrivers/gcp_driver.py
@@ -32,7 +32,7 @@ def get_all_ips(instance):
     try:
         ip_list.append(instance["networkInterfaces"][0]
                        ["accessConfigs"][0]["natIP"])  # Public
-    except ValueError:
+    except Exception as e:
         pass
 
     ip_list.append(instance["networkInterfaces"][0]["networkIP"])  # Private
@@ -58,7 +58,7 @@ def create_node_from_server(server):
     # temporal workaround
     try:
         public_ip = server["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
-    except ValueError:
+    except Exception as e:
         public_ip = 'None'
 
     return Node(

--- a/powerfulseal/k8s/k8s_inventory.py
+++ b/powerfulseal/k8s/k8s_inventory.py
@@ -80,27 +80,29 @@ class K8sInventory():
             selector=selector,
             deployment_name=deployment_name,
         )
-        pod_objects = [
-            Pod(
-                num=i,
-                name=item.metadata.name,
-                namespace=item.metadata.namespace,
-                uid=item.metadata.uid,
-                host_ip=item.status.host_ip,
-                ip=item.status.pod_ip,
-                container_ids=[
-                    status.container_id
-                    for status in item.status.container_statuses
-                ] if item.status.container_statuses else [],
-                restart_count=sum([
-                    status.restart_count
-                    for status in item.status.container_statuses
-                ]),
-                state=item.status.phase,
-                labels=item.metadata.labels,
-                meta=item,
-            ) for i, item in enumerate(pods)
-        ] if pods else []
+        pod_objects = []
+        if pods is not None:
+            for i, item in enumerate(pods):
+                        container_ids = []
+                        restart_count = []
+                        if item.status.container_statuses:
+                            for status in item.status.container_statuses:
+                                container_ids.append(status.container_id)
+                                restart_count.append(status.restart_count)
+                        
+                        pod_objects.append(Pod(
+                            num=i,
+                            name=item.metadata.name,
+                            namespace=item.metadata.namespace,
+                            uid=item.metadata.uid,
+                            host_ip=item.status.host_ip,
+                            ip=item.status.pod_ip,
+                            container_ids=container_ids,
+                            restart_count=sum(restart_count),
+                            state=item.status.phase,
+                            labels=item.metadata.labels,
+                            meta=item,
+                        ))
         self.last_pods = pod_objects
         return pod_objects
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.2.0',
+    version='2.3.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',
@@ -32,7 +32,11 @@ setup(
         'flask-swagger-ui>=3.18.0<4',
         'coloredlogs>=10.0.0,<11.0.0',
         'six>=1.12.0,<2',
-        'paramiko>=2.5.0,<3'
+        'paramiko>=2.5.0,<3',
+        'google-api-python-client>=1.7.8',
+        'google-auth>=1.6.2',
+        'google-auth-httplib2>=0.0.3',
+        'oauth2client>=4.1.3'
     ],
     extras_require={
         'testing': [

--- a/tests/clouddrivers/test_gcp_driver.py
+++ b/tests/clouddrivers/test_gcp_driver.py
@@ -1,0 +1,97 @@
+import pytest
+from mock import patch, MagicMock
+from powerfulseal.clouddrivers import gcp_driver
+from powerfulseal.node import Node
+
+PRIVATE_IPS = ['198.168.1.1', '198.168.2.1']
+PUBLIC_IPS = ['31.31.31.31', '41.41.41.41']
+INVALID_IP = '198.168.3.1'
+
+GCLOUD_CONFIG = '''
+{
+  "compute": {
+    "region": "us-central1"
+  },
+  "core": {
+    "project": "marine-foundry-184612"
+  }
+}
+'''
+
+
+class Computeinstance():
+    def __init__(
+            self,
+            id,
+            private_ip_address,
+            public_ip_address,
+            zone,
+            state,
+            name):
+        self.private_ip_address = private_ip_address
+        self.id = id
+        self.public_ip_address = public_ip_address
+        self.placement = zone
+        self.state = state
+        self.name = name
+
+    def show_as_dict(self):
+        return {'name': self.name,
+                'id': self.id,
+                'zone': 'url/' + self.placement,
+                'status': self.state,
+                'networkInterfaces': [{'networkIP': self.private_ip_address,
+                                       'accessConfigs': [{'natIP': self.public_ip_address}]}]}
+
+
+@pytest.fixture
+def compute_instances():
+    return [
+        Computeinstance(
+            id="6285420104283695093",
+            private_ip_address="198.168.1.1",
+            zone="us-central1",
+            public_ip_address="31.31.31.31",
+            state="RUNNING",
+            name="gke--cluster-1-pool-1-902c09f2-l5hf").show_as_dict(),
+        Computeinstance(
+            id="5611252125784513532",
+            private_ip_address="198.168.2.1",
+            zone="us-central2",
+            public_ip_address="41.41.41.41",
+            state="RUNNING",
+            name="gke--cluster-1-pool-1-906c09e4-l9gh").show_as_dict()]
+
+
+@patch('powerfulseal.clouddrivers.gcp_driver.create_connection_from_config')
+def test_get_by_ip_private_ip_nodes(
+        create_connection_from_config,
+        compute_instances):
+    driver = gcp_driver.GCPDriver(config=GCLOUD_CONFIG)
+    driver.remote_servers = compute_instances
+    node_index = 0
+    nodes = driver.get_by_ip(PRIVATE_IPS[node_index])
+    assert compute_instances[node_index]['id'] is nodes.id
+    assert compute_instances[node_index]['zone'] == 'url/' + nodes.az
+    assert compute_instances[node_index]['networkInterfaces'][0]['networkIP'] == nodes.ip
+
+
+@patch('powerfulseal.clouddrivers.gcp_driver.create_connection_from_config')
+def test_get_by_ip_public_ip_nodes(
+        create_connection_from_config,
+        compute_instances):
+    driver = gcp_driver.GCPDriver(config=GCLOUD_CONFIG)
+    driver.remote_servers = compute_instances
+    node_index = 1
+    nodes = driver.get_by_ip(PUBLIC_IPS[node_index])
+    assert compute_instances[node_index]['id'] is nodes.id
+    assert compute_instances[node_index]['zone'] == 'url/' + nodes.az
+    assert compute_instances[node_index]['networkInterfaces'][0]['accessConfigs'][0]['natIP'] == nodes.extIp
+
+
+@patch('powerfulseal.clouddrivers.gcp_driver.create_connection_from_config')
+def test_get_by_ip_no_nodes(create_connection_from_config, compute_instances):
+    driver = gcp_driver.GCPDriver(config=GCLOUD_CONFIG)
+    driver.remote_servers = compute_instances
+    nodes = driver.get_by_ip(INVALID_IP)
+    assert nodes is None


### PR DESCRIPTION
PR adding the GCP cloud driver. This PR closes #123 and is related with #80.

- Implementation of Google Cloud that works with managed (GKE) and custom Kubernetes clusters running on top of Google Cloud Compute.
- Supports zone and regional clusters.
- Supports authentification with Service account and User account. 
- Uses default project/region from gcloud SDK, but supports using a custom configuration file.

This PR also adds testing for the driver, needed dependencies on setup.py, driver arguments for cli, docs in README.md and minor version bump  :smiley:

On the other hand, a little problem closely related to the driver is addressed too! Found that running the ```pods``` command in interactive mode crashed... And seemed that with this little refactor, for gracefully handling missing parameters, It's working now. Hope it's not a regression and would love to hear if I'm missing something or there is an easier way to tackle it!