### PR TITLE
Transition from Heapster to metrics-server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 INOTIFY_CALL ?= inotifywait -e modify -r ./powerfulseal ./tests
 NPM_CALL ?= cd powerfulseal/web/ui && npm install && npm run build
 TOX_CALL ?= tox -r
-HEAPSTER_URL ?= http://heapster.kube-system.svc.kubernetes.cluster/
+METRICS_SERVER_URL ?= http://metrics-server.kube-system.svc.kubernetes.cluster/
 CLOUD_OPTION ?= --openstack
 
 test:
@@ -18,6 +18,10 @@ upload:
 	rm -rfv powerfulseal.egg-info
 	python setup.py sdist
 	twine upload dist/*
+
+clean:
+	find -name '*.pyc' -delete
+	find -name '__pycache__' -delete
 
 
 # EXAMPLES OF RUNNING THE SEAL
@@ -89,7 +93,7 @@ demo:
 			--prometheus-host 0.0.0.0 \
 			--prometheus-port 9999 \
 			--ssh-allow-missing-host-keys \
-			--heapster-path $(HEAPSTER_URL)
+			--metrics-server-path $(METRICS_SERVER_URL)
 
 
 # THE EXAMPLES BELOW SHOULD WORK FOR MINIKUBE
@@ -138,4 +142,4 @@ minikube-interactive:
 			--override-ssh-host `minikube ip`
 
 
-.PHONY: test watch web run run-headless validate label demo
+.PHONY: test watch web run run-headless validate label demo clean

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ __PowerfulSeal__ works in several modes:
 
 - __Label__ mode allows you to specify which pods to kill with a small number of options by adding `seal/` labels to pods. This is a more imperative alternative to autonomous mode.  
 
-- __Demo__ mode allows you to point the Seal at a cluster and a `heapster` server and let it try to figure out what to kill based on the resource utilisation.
+- __Demo__ mode allows you to point the Seal at a cluster and a `metrics-server` server and let it try to figure out what to kill based on the resource utilisation.
 
 ## Modes of operation
 
@@ -386,7 +386,7 @@ Prometheus settings:
 
 The main way to use PowerfulSeal is to write a policy file for Autonomous mode which reflects realistic failures in your system. However, PowerfulSeal comes with a demo mode to demonstrate how it can cause chaos on your Kubernetes cluster. Demo mode gets all the pods in the cluster, selects those which are using the most resources, then kills them based on a probability.
 
-Demo mode requires [Heapster](https://github.com/kubernetes/heapster). To run demo mode, use the `demo` subcommand along with `--heapster-path` (path to heapster without a trailing slash, e.g., `http://localhost:8001/api/v1/namespaces-kube-system/services/heapster/proxy`). You can also optionally specify `--aggressiveness` (from `1` (weakest) to `5` (strongest)) inclusive, as well as `--[min/max]-seconds-between-runs`.
+Demo mode requires [metrics-server](https://github.com/kubernetes-incubator/metrics-server). To run demo mode, use the `demo` subcommand along with `--metrics-server-path` (path to metrics-server without a trailing slash, e.g., `http://localhost:8080/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy`). You can also optionally specify `--aggressiveness` (from `1` (weakest) to `5` (strongest)) inclusive, as well as `--[min/max]-seconds-between-runs`.
 
 ```sh
 $ seal demo --help
@@ -406,8 +406,8 @@ usage: seal demo [-h] --kubeconfig KUBECONFIG
                  [--max-seconds-between-runs MAX_SECONDS_BETWEEN_RUNS]
                  [--stdout-collector | --prometheus-collector]
                  [--prometheus-host PROMETHEUS_HOST]
-                 [--prometheus-port PROMETHEUS_PORT] --heapster-path
-                 HEAPSTER_PATH [--aggressiveness AGGRESSIVENESS]
+                 [--prometheus-port PROMETHEUS_PORT] --metrics-server-path
+                 METRICS_SERVER_PATH [--aggressiveness AGGRESSIVENESS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -478,9 +478,9 @@ Prometheus settings:
                         Port to expose Prometheus metrics via the HTTP server
                         when using the --prometheus-collector flag
 
-Heapster settings:
-  --heapster-path HEAPSTER_PATH
-                        Base path of Heapster without trailing slash
+metrics-server settings:
+  --metrics-server-path METRICS_SERVER_PATH
+                        Base path of metrics-server without trailing slash
   --aggressiveness AGGRESSIVENESS
                         Aggressiveness of demo mode (default: 3)
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ __PowerfulSeal__ works in several modes:
 
 - __Label__ mode allows you to specify which pods to kill with a small number of options by adding `seal/` labels to pods. This is a more imperative alternative to autonomous mode.  
 
-- __Demo__ mode allows you to point the Seal at a cluster and a `metrics-server` server and let it try to figure out what to kill based on the resource utilization.
+- __Demo__ mode allows you to point the Seal at a cluster and a `metrics-server` server and let it try to figure out what to kill, based on the resource utilization.
 
 ## Modes of operation
 

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -24,7 +24,7 @@ import sys
 import os
 
 import powerfulseal.version
-from powerfulseal.k8s.heapster_client import HeapsterClient
+from powerfulseal.k8s.metrics_server_client import MetricsServerClient
 from powerfulseal.policy.demo_runner import DemoRunner
 from prometheus_client import start_http_server
 from powerfulseal.metriccollectors import StdoutCollector, PrometheusCollector
@@ -349,7 +349,7 @@ def parse_args(args):
         help=(
             'Starts in demo mode. '
             'It reads Kubernetes pods in specified namespaces, and reads '
-            'HEAPSTER metrics to guess what\'s worth killing. '
+            'metrics-server metrics to guess what\'s worth killing. '
             'This is a DAEMONLESS mode of operation. '
         ),
     )
@@ -359,10 +359,10 @@ def parse_args(args):
     add_metrics_options(parser_demo)
 
     demo_options = parser_demo.add_argument_group(
-        title='Heapster settings'
+        title='metrics-server settings'
     )
-    demo_options.add_argument('--heapster-path',
-        help='Base path of Heapster without trailing slash',
+    demo_options.add_argument('--metrics-server-path',
+        help='Base path of metrics-server without trailing slash',
         required=True
     )
     demo_options.add_argument('--aggressiveness',
@@ -608,13 +608,13 @@ def main(argv):
             print("Aggressiveness must be between 1 and 5 inclusive")
             os.exit(1)
 
-        heapster_client = HeapsterClient(args.heapster_path)
+        metrics_server_client = MetricsServerClient(args.metrics_server_path)
         demo_runner = DemoRunner(
             inventory,
             k8s_inventory,
             driver,
             executor,
-            heapster_client,
+            metrics_server_client,
             aggressiveness=aggressiveness,
             min_seconds_between_runs=args.min_seconds_between_runs,
             max_seconds_between_runs=args.max_seconds_between_runs,

--- a/powerfulseal/k8s/metrics_server_client.py
+++ b/powerfulseal/k8s/metrics_server_client.py
@@ -20,17 +20,17 @@ try:
 except ImportError:
     JSONDecodeError = ValueError
 
-POD_METRICS_PATH = "/apis/metrics/v1alpha1/pods"
+POD_METRICS_PATH = "/apis/metrics.k8s.io/v1beta1/pods"
 
-# Value is a fraction of a single CPU core (e.g., 1m = 1 / 1000 => 0.001)
-CPU_UNITS = {'m': 1000}
+# Value is a fraction of a single CPU core (e.g., 1n = 1 / 1000000000 => 0.000000001)
+CPU_UNITS = {'n': 1000000000}
 # Value is a multiple of a byte (e.g., 1Ki => 1000)
 MEMORY_UNITS = {'Ki': 1000, 'Mi': 1000000, 'Gi': 1000000000, 'Ti': 1000000000000, 'Pi': 1000000000000000}
 
 
-class HeapsterClient:
+class MetricsServerClient:
     """
-    Retrieves CPU and memory metrics from Heapster
+    Retrieves CPU and memory metrics from metrics-server
     """
 
     def __init__(self, base_path, logger=None):
@@ -69,8 +69,9 @@ class HeapsterClient:
 
     def parse_cpu_string(self, cpu):
         """
-        Returns CPU in number of cores (e.g., "120m" => 0.12)
+        Returns CPU in number of cores (e.g., "120n" => 0.0000012)
         """
+        print(cpu)
         if len(cpu) < 2 or is_numeric(cpu[-1]):
             return float(cpu)
 
@@ -93,7 +94,7 @@ class HeapsterClient:
             raise ValueError("Memory is malformed")
         elif is_penultimate_numeric and not is_last_numeric:
             # Unimplemented case of single-character suffixes (it is unknown
-            # whether Heapster implements this). Currently, memory is handled
+            # whether metric-server implements this). Currently, memory is handled
             # with power-of-two suffixes (e.g., Ki, Mi, etc.)
             raise NotImplementedError("Single character units are not implemented")
         else:

--- a/powerfulseal/policy/demo_runner.py
+++ b/powerfulseal/policy/demo_runner.py
@@ -24,7 +24,7 @@ class DemoRunner:
     Kills pods based on CPU core usage and memory usage to demonstrate how chaos
     can be created by killing pods which are busy.
 
-    The CPU and memory information is retrieved from Heapster. Then, pods are
+    The CPU and memory information is retrieved from metrics-server. Then, pods are
     first sorted by their CPU usage and memory and killed based on filters.
 
     - Pods are first filtered based on what quintile they in: an aggressiveness of
@@ -101,7 +101,7 @@ class DemoRunner:
     def fill_metrics(self, pods):
         """
         Adds a metrics variable to each Pod variable in a list of pods. Retrieves
-        the metrics from Heapster.
+        the metrics from metrics-server.
         """
         metrics = self.metric_client.get_pod_metrics()
         filled_pods = []

--- a/tests/k8s/test_metrics_server_client.py
+++ b/tests/k8s/test_metrics_server_client.py
@@ -16,11 +16,11 @@ import json
 import mock
 import pytest
 
-from powerfulseal.k8s.heapster_client import HeapsterClient
+from powerfulseal.k8s.metrics_server_client import MetricsServerClient
 
 
 def test_get_pod_metrics():
-    heapster = HeapsterClient(None)
+    metrics_server = MetricsServerClient(None)
 
     def mocked_response(*args):
         mocked = mock.MagicMock()
@@ -38,14 +38,14 @@ def test_get_pod_metrics():
         {
           "name": "container-1a",
           "usage": {
-            "cpu": "1m",
+            "cpu": "2000n",
             "memory": "68896Ki"
           }
         },
         {
           "name": "container-1b",
           "usage": {
-            "cpu": "1m",
+            "cpu": "300n",
             "memory": "2Ki"
           }
         }
@@ -60,7 +60,7 @@ def test_get_pod_metrics():
         {
           "name": "container-2a",
           "usage": {
-            "cpu": "3m",
+            "cpu": "207691n",
             "memory": "36840Ki"
           }
         }
@@ -71,19 +71,19 @@ def test_get_pod_metrics():
           """)
         return mocked
 
-    with mock.patch('powerfulseal.k8s.heapster_client.requests.get',
+    with mock.patch('powerfulseal.k8s.metrics_server_client.requests.get',
                     side_effect=mocked_response):
-        result = heapster.get_pod_metrics()
+        result = metrics_server.get_pod_metrics()
         assert len(result) == 1 and 'default' in result
         assert len(result['default']) == 2
         assert result == {
             'default': {
                 'abc': {
-                    'cpu': 0.002,
+                    'cpu': 0.0000023,
                     'memory': 68898000
                 },
                 'def': {
-                    'cpu': 0.003,
+                    'cpu': 0.000207691,
                     'memory': 36840000
                 }
             }
@@ -91,29 +91,29 @@ def test_get_pod_metrics():
 
 
 def test_parse_cpu_string():
-    heapster = HeapsterClient(None)
-    assert heapster.parse_cpu_string('1') == pytest.approx(1)
-    assert heapster.parse_cpu_string('100') == pytest.approx(100)
-    assert heapster.parse_cpu_string('1m') == pytest.approx(0.001)
-    assert heapster.parse_cpu_string('10m') == pytest.approx(0.01)
+    metrics_server = MetricsServerClient(None)
+    assert metrics_server.parse_cpu_string('1') == pytest.approx(1)
+    assert metrics_server.parse_cpu_string('100') == pytest.approx(100)
+    assert metrics_server.parse_cpu_string('1n') == pytest.approx(0.000000001)
+    assert metrics_server.parse_cpu_string('10n') == pytest.approx(0.00000001)
 
 
 def test_parse_memory_string():
-    heapster = HeapsterClient(None)
-    assert heapster.parse_memory_string('68896') == 68896
-    assert heapster.parse_memory_string('68896Mi') == 68896000000
-    assert heapster.parse_memory_string('68896Ki') == 68896000
-    assert heapster.parse_memory_string('68Gi') == 68000000000
-    assert heapster.parse_memory_string('2Ti') == 2000000000000
-    assert heapster.parse_memory_string('1') == 1
-    assert heapster.parse_memory_string('0') == 0
-    assert heapster.parse_memory_string('16') == 16
+    metrics_server = MetricsServerClient(None)
+    assert metrics_server.parse_memory_string('68896') == 68896
+    assert metrics_server.parse_memory_string('68896Mi') == 68896000000
+    assert metrics_server.parse_memory_string('68896Ki') == 68896000
+    assert metrics_server.parse_memory_string('68Gi') == 68000000000
+    assert metrics_server.parse_memory_string('2Ti') == 2000000000000
+    assert metrics_server.parse_memory_string('1') == 1
+    assert metrics_server.parse_memory_string('0') == 0
+    assert metrics_server.parse_memory_string('16') == 16
 
     with pytest.raises(NotImplementedError) as _:
-        heapster.parse_memory_string('6889M')
+        metrics_server.parse_memory_string('6889N')
 
     with pytest.raises(ValueError) as _:
-        heapster.parse_memory_string('688M9')
+        metrics_server.parse_memory_string('688N9')
 
     with pytest.raises(KeyError) as _:
-        heapster.parse_memory_string('688Ei')
+        metrics_server.parse_memory_string('688Ei')


### PR DESCRIPTION
PR handling the transition as discussed. This PR closes #109.

Heapster has reached EOL with Kubernetes 1.13 and metrics-server has become the new standard. This commit fixes the incompatibilities between them, for keeping demo mode working,  like the METRICS_PATH and the use of nanocores instead of milicores.

Also, all past references to Heapster have been modified and the test suite has been adapted.

Signed-off-by: dgzlopes <danielgonzalezlopes@gmail.com>