### PR TITLE
Handle killing pods on pending state

### DIFF
--- a/powerfulseal/cli/pscmd.py
+++ b/powerfulseal/cli/pscmd.py
@@ -40,6 +40,11 @@ DEFAULT_COLOR_KEYWORDS = {
     "pod": "blue",
     "ip": "yellow",
     "extIp": "yellow",
+    "Running": "green",
+    "Succeeded": "green",
+    "Pending": "grey",
+    "Failed": "red",
+    "Unknown": "red"
 }
 # couple of helpers
 def colour_output(output, extras=None):
@@ -427,6 +432,8 @@ class PSCmd(cmd.Cmd):
                 break
         if pod is None:
             return print("Pod number not found.")
+        if pod.state == 'Pending':
+            return print("Can't kill pod on pending state")
 
         # find the node
         node = self.inventory.get_node_by_ip(pod.host_ip)


### PR DESCRIPTION
PR adds better handling when trying to kill a pod on pending state. This PR closes: #127 

1. Added status check when trying to kill some pod on pending state.
2. Added a color scheme to pods state [0] for easier visualization on
interactive mode.

[0] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

Signed-off-by: dgzlopes <danielgonzalezlopes@gmail.com>