### PR TITLE
remove unneeded import

### DIFF
--- a/powerfulseal/clouddrivers/azure_driver.py
+++ b/powerfulseal/clouddrivers/azure_driver.py
@@ -9,7 +9,6 @@ from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.compute import ComputeManagementClient
-from azure.mgmt.compute.models import DiskCreateOption
 
 def create_connection_from_config():
     """ Creates a new Azure api connection """


### PR DESCRIPTION
Signed-off-by: Mikel Nelson <github@mikelnelson.net>

Azure driver DeprecationWarning #135

Removed unneeded import that is causing deprecation warnings.

Ran tox -r. validated that deprecation warning does not occur.

Closes #135
