### PR TITLE
Try to decrease docker image size by using a multi-stage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
-#  - "3.7"
+  - "3.7"
 
 # enable docker in Travis
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
-  - "3.7"
+#  - "3.7"
 
 # enable docker in Travis
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,12 @@ script:
   - make build
   - docker images
   - docker run `make version` --help
+
+# push an image on tags
+deploy:
+  provider: script
+  script: bash docker_deploy.sh
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: -n "$DOCKER_PASSWORD"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,6 +23,9 @@ LABEL MAINTAINER="Mikolaj Pawlikowski <opensource@bloomberg.net>"
 
 # copy over the site-packages from builder
 COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+# also copy over the executable helpers
+COPY --from=builder /usr/local/bin/powerfulseal /usr/local/bin/seal /usr/local/bin/
+# list the installed packages and their versions
 RUN pip list
 
 ENTRYPOINT ["powerfulseal"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,16 +1,28 @@
-FROM python:3.7-slim-buster
-LABEL MAINTAINER="Mikolaj Pawlikowski <opensource@bloomberg.net>"
+# our builder image
+FROM python:3.7-slim-buster as builder
 
-WORKDIR /powerfulseal
-
+# install all the build dependencies
 RUN apt-get update && \
     apt-get install -y build-essential && \
     apt-get clean && \
     apt-get autoclean && \
     apt-get autoremove
 
+# copy powerfulseal package
+WORKDIR /powerfulseal
 COPY Makefile LICENSE README.md setup.py /powerfulseal/
 COPY powerfulseal/ /powerfulseal/powerfulseal/
+
+# install it with pip
 RUN pip --no-cache-dir install . && pip list .
+
+
+# the actual image we will be pushing up
+FROM python:3.7-slim-buster
+LABEL MAINTAINER="Mikolaj Pawlikowski <opensource@bloomberg.net>"
+
+# copy over the site-packages from builder
+COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+RUN pip list
 
 ENTRYPOINT ["powerfulseal"]


### PR DESCRIPTION
This PR aims to decrease the size of the `powerfulseal` docker image.

This should be dropping it from 631MB to 398MB.


```sh
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
powerfulseal        2.4.0               80db59e06763        1 second ago        398MB
<none>              <none>              b87142b937ba        17 seconds ago      631MB
python              3.7-slim-buster     f96c28b7013f        8 hours ago         179MB
```