### PR TITLE
Fix travis link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PowerfulSeal [![Travis](https://img.shields.io/travis/bloomberg/powerfulseal.svg)](https://travis-ci.org/bloomberg/powerfulseal) [![PyPI](https://img.shields.io/pypi/v/powerfulseal.svg)](https://pypi.python.org/pypi/powerfulseal)
+# PowerfulSeal [![Travis](https://img.shields.io/travis/bloomberg/powerfulseal.svg)](https://travis-ci.com/bloomberg/powerfulseal) [![PyPI](https://img.shields.io/pypi/v/powerfulseal.svg)](https://pypi.python.org/pypi/powerfulseal)
 
 __PowerfulSeal__ adds chaos to your Kubernetes clusters, so that you can detect problems in your systems as early as possible. It kills targeted pods and takes VMs up and down.
 


### PR DESCRIPTION
The link on CI badge was pointing to travis-ci.org, but the repository is being built on travis-ci.com [[0](https://devops.stackexchange.com/a/4305)]

[0] https://devops.stackexchange.com/a/4305