### PR TITLE
Allow Travis-CI to build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 branches:
   only:
     - master
+    - /^\d+\.\d+\.\d+(-\S*)?$/
 
 # command to install dependencies
 install:


### PR DESCRIPTION
The branch filter previously added only allows builds from 'master',
which stops Travis-CI from building tags. This patch adds a regex to the
filter allowing any branches (tags) whose names match the regex to be
built.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>
