### PR TITLE
Enable pushing of packages to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,18 @@ script:
   - docker images
   - docker run `make version` --help
 
-# push images to DockerHub on tags
+# push images to DockerHub and PyPI on tags
 deploy:
-  provider: script
-  script: bash docker_deploy.sh
-  skip_cleanup: true
-  on:
-    tags: true
-    condition: -n "$DOCKER_PASSWORD"
-
-# push packages to PyPI on tags
-deploy:
-  provider: pypi
-  user: "$PYPI_USER"
-  password: "$PYPI_PASSWORD"
-  skip_cleanup: true
-  on:
-    tags: true
-    condition: -n "$PYPI_PASSWORD"
+  - provider: script
+    script: bash docker_deploy.sh
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "$DOCKER_PASSWORD"
+  - provider: pypi
+    user: "$PYPI_USER"
+    password: "$PYPI_PASSWORD"
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "$PYPI_PASSWORD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - docker images
   - docker run `make version` --help
 
-# push an image on tags
+# push images to DockerHub on tags
 deploy:
   provider: script
   script: bash docker_deploy.sh
@@ -33,3 +33,13 @@ deploy:
   on:
     tags: true
     condition: -n "$DOCKER_PASSWORD"
+
+# push packages to PyPI on tags
+deploy:
+  provider: pypi
+  user: "$PYPI_USER"
+  password: "$PYPI_PASSWORD"
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: -n "$PYPI_PASSWORD"


### PR DESCRIPTION
This commit prepares .travis.yml to enable pushing of packages to
PyPI when tags are pushed to the repository.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>
