### PR TITLE
Work around the `text/markdown` support in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ branches:
   only:
     - master
     - /^\d+\.\d+\.\d+(-\S*)?$/
+    
+# install pandoc
+before_install:
+  - sudo apt-get install pandoc
 
 # command to install dependencies
 install:
@@ -24,6 +28,7 @@ script:
   - make build
   - docker images
   - docker run `make version` --help
+  - pandoc -s README.md -t rst -o README.md
 
 # push images to DockerHub and PyPI on tags
 deploy:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license=read('LICENSE'),
     description='PowerfulSeal - a powerful testing tool for Kubernetes clusters',
     long_description=read('README.md'),
-    long_description_content_type="text/markdown",
+    #long_description_content_type="text/markdown",
     install_requires=[
         'ConfigArgParse>=0.11.0,<1',
         'Flask>=1.0.0,<2',


### PR DESCRIPTION
This installs pandoc and sneakily changes format of `README.md` from Markdown to reStructuredText, so that `PyPI` upload doesn't choke.


- https://github.com/pypa/warehouse/pull/4099#issuecomment-393620919
- https://github.com/pypa/warehouse/issues/4079#issuecomment-392924698