### PR TITLE
Don't run Travis-CI deployment more than once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+      python: "3.6"
       condition: -n "$DOCKER_PASSWORD"
   - provider: pypi
     user: "$PYPI_USER"
@@ -44,4 +45,5 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+      python: "3.6"
       condition: -n "$PYPI_PASSWORD"


### PR DESCRIPTION
This project's Travis-CI build configuration builds the entire project
more than once, for multiple versions of Python. The deployment
configuration should *not* do this, it should only deploy once for the
latest version of Python available.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>
