### PR TITLE
Support in cluster config

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -45,10 +45,8 @@ def add_kubernetes_options(parser):
     args_kubernetes.add_argument(
         '--kubeconfig',
         help='Location of kube-config file',
-        default=os.environ.get('KUBECONFIG', '~/.kube/config'),
-        type=os.path.expanduser,
+        type=os.path.expanduser
     )
-
 def add_ssh_options(parser):
     # SSH
     args_ssh = parser.add_argument_group('SSH settings')

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -38,6 +38,18 @@ from ..k8s import K8sClient, K8sInventory
 from .pscmd import PSCmd
 from ..policy import PolicyRunner
 
+KUBECONFIG_DEFAULT_PATH = "~/.kube/config"
+
+def parse_kubeconfig(args):
+    """
+        if explicitly set, use the --kubeconfig value
+        otherwise, check if KUBECONFIG is set
+        if not, check if there is `~/.kube/config` available
+        else try to build in-cluster config
+    """
+    logger = logging.getLogger(__name__)
+    kube_config = None
+    return kube_config
 
 def add_kubernetes_options(parser):
     # Kubernetes
@@ -444,8 +456,7 @@ def main(argv):
     ##########################################################################
     # KUBERNETES
     ##########################################################################
-    kube_config = args.kubeconfig
-    logger.info("Creating kubernetes client with config %s", kube_config)
+    kube_config = parse_kubeconfig(args)
     k8s_client = K8sClient(kube_config=kube_config)
     k8s_inventory = K8sInventory(k8s_client=k8s_client)
 

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -49,6 +49,18 @@ def parse_kubeconfig(args):
     """
     logger = logging.getLogger(__name__)
     kube_config = None
+    expanded_home_kube_config_path = os.path.expanduser(KUBECONFIG_DEFAULT_PATH)
+    if args.kubeconfig:
+        kube_config = args.kubeconfig
+        logger.info("Creating kubernetes client with config %s from --kubeconfig flag", kube_config)
+    elif os.environ.get("KUBECONFIG"):
+        kube_config = os.path.expanduser(os.environ.get("KUBECONFIG"))
+        logger.info("Creating kubernetes client with config %s from KUBECONFIG env var", kube_config)
+    elif os.path.exists(expanded_home_kube_config_path):
+        kube_config = expanded_home_kube_config_path
+        logger.info("Creating kubernetes client with config %s (path found for backwards compatibility)", kube_config)
+    else:
+        logger.info("Creating kubernetes client with in-cluster config")
     return kube_config
 
 def add_kubernetes_options(parser):

--- a/powerfulseal/k8s/k8s_client.py
+++ b/powerfulseal/k8s/k8s_client.py
@@ -27,6 +27,8 @@ class K8sClient():
     def __init__(self, kube_config=None, logger=None):
         if kube_config:
             kubernetes.config.load_kube_config(config_file=kube_config)
+        else:
+            kubernetes.config.load_incluster_config()
         self.client_corev1api = kubernetes.client.CoreV1Api()
         self.client_extensionsv1beta1api = kubernetes.client.ExtensionsV1beta1Api()
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.4.1',
+    version='2.5.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/tests/cli/test_args.py
+++ b/tests/cli/test_args.py
@@ -32,7 +32,7 @@ def test_kubeconfig_default():
         '--inventory-kubernetes',
         '--no-cloud'
     ])
-    assert parser.kubeconfig == HOME + '/.kube/config'
+    assert parser.kubeconfig is None
 
 
 def test_interactive_mode_integration():

--- a/tests/cli/test_kubeconfig.py
+++ b/tests/cli/test_kubeconfig.py
@@ -1,0 +1,79 @@
+# Copyright 2018 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+from mock import patch, MagicMock
+
+import powerfulseal
+from powerfulseal.cli.__main__ import parse_args
+
+HOME = os.path.expanduser("~")
+
+
+def test_flag_takes_precedence(monkeypatch, tmpdir):
+    p1 = tmpdir.join("kubeconfig1")
+    p1.write("{}")
+    p2 = tmpdir.join("kubeconfig2")
+    p2.write("{}")
+    monkeypatch.setenv('KUBECONFIG', str(p1.realpath()))
+    with patch("powerfulseal.cli.__main__.KUBECONFIG_DEFAULT_PATH", str(p2.realpath())):
+        kube_config = powerfulseal.cli.__main__.parse_kubeconfig(parse_args([
+            'interactive',
+            '--kubeconfig', '~/LOL',
+            '--inventory-kubernetes',
+            '--no-cloud'
+        ]))
+        assert kube_config == HOME + "/LOL"
+
+
+def test_env_var_takes_2nd_precedence(monkeypatch, tmpdir):
+    p1 = tmpdir.join("kubeconfig1")
+    p1.write("{}")
+    p2 = tmpdir.join("kubeconfig2")
+    p2.write("{}")
+    monkeypatch.setenv('KUBECONFIG', str(p1.realpath()))
+    with patch("powerfulseal.cli.__main__.KUBECONFIG_DEFAULT_PATH", str(p2.realpath())):
+        kube_config = powerfulseal.cli.__main__.parse_kubeconfig(parse_args([
+            'interactive',
+            '--inventory-kubernetes',
+            '--no-cloud'
+        ]))
+        assert kube_config == str(p1.realpath())
+
+
+def test_home_kubeconfig_takes_3rd_precedence(monkeypatch, tmpdir):
+    p2 = tmpdir.join("kubeconfig2")
+    p2.write("{}")
+    monkeypatch.delenv('KUBECONFIG', raising=False)
+    with patch("powerfulseal.cli.__main__.KUBECONFIG_DEFAULT_PATH", str(p2.realpath())):
+        kube_config = powerfulseal.cli.__main__.parse_kubeconfig(parse_args([
+            'interactive',
+            '--inventory-kubernetes',
+            '--no-cloud'
+        ]))
+        assert kube_config == str(p2.realpath())
+
+
+def test_in_cluster_takes_4th_precedence(monkeypatch, tmpdir):
+    p2 = tmpdir.join("kubeconfig2")
+    p2.write("{}")
+    monkeypatch.delenv('KUBECONFIG', raising=False)
+    with patch("powerfulseal.cli.__main__.KUBECONFIG_DEFAULT_PATH", "/probably/doesnt/exist"):
+        kube_config = powerfulseal.cli.__main__.parse_kubeconfig(parse_args([
+            'interactive',
+            '--inventory-kubernetes',
+            '--no-cloud'
+        ]))
+        assert kube_config == None


### PR DESCRIPTION
This introduces support for in-cluster config, while maintaining backwards compatible behaviour.

The precedence is as follows:
- `--kubeconfig` flag
- `KUBECONFIG` env var
- `~/.kube/config` for backwards compatibility
- in-cluster

Closes https://github.com/bloomberg/powerfulseal/issues/161