### PR TITLE
(example)k8s_manifest: add powerfulseal deployment manifests

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,15 @@
+## DEPLOY POWERFULSEAL ON YOUR KUBERNETES CLUSTER
+
+Powerfulseal can be deployed on your Kubernetes cluster to perform random chaos the application services. 
+
+### STEPS TO FOLLOW
+
+- Apply the rbac.yml (choose the appropriate namespace) to setup a service account with sufficient privileges
+
+  `kubectl apply -f rbac.yml` 
+
+- Precondition the powerfulseal.yml to reflect the desired chaos policy & application service (namespace, labels) in the configmap data
+
+  `kubectl apply -f powerfulseal.yml` 
+
+ 

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policy
+  namespace: default
+data:
+  policy_kill_random_default.yml: |-
+    config: 
+      minSecondsBetweenRuns: 1
+      maxSecondsBetweenRuns: 10
+    nodeScenarios: []
+    podScenarios:
+      - name: "delete random pods in default namespace"
+        match:
+          - labels:
+              namespace: "default"
+              selector: "app=hello"
+        filters:
+          - randomSample:
+              size: 1
+        actions:
+          - kill:
+              probability: 0.77
+              force: true    
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: powerfulseal
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: powerfulseal
+    spec:
+      serviceAccountName: powerfulseal
+      containers:
+        - name: powerfulseal
+          image: bloomberg/powerfulseal:2.5.0
+          args: 
+          - autonomous
+          - --inventory-kubernetes 
+          - --no-cloud
+          - --policy-file=/root/policy_kill_random_default.yml
+          - --use-pod-delete-instead-of-ssh-kill
+          volumeMounts: 
+            - name: policyfile
+              mountPath: /root/policy_kill_random_default.yml
+              subPath: policy_kill_random_default.yml
+      volumes:
+        - name: policyfile
+          configMap: 
+            name: policy
+
+    

--- a/kubernetes/rbac.yml
+++ b/kubernetes/rbac.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: powerfulseal
+  name: powerfulseal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: powerfulseal
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: powerfulseal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: powerfulseal
+subjects:
+- kind: ServiceAccount
+  name: powerfulseal
+  namespace: default


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

*Issue number of the reported bug or feature request: #<number>*
fixes #165 

**Describe your changes**
A clear and concise description of the changes you have made.

- Adds example Kubernetes deployment manifests (rbac, powerfulseal) with a brief README to specify run steps. 

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

- Applied the spec on a GKE cluster & observed successful pod chaos

**Additional context**
Add any other context about your contribution here.

- The image referred to in the powerfulseal.yml - `bloomberg/powerfulseal:2.5.0` is not present at this point. Open to replacing it with a placeholder OR keep the PR waiting until an actual image is available. 