### PR TITLE
Don't use the long markdown description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+long_description = """
+**PowerfulSeal** adds chaos to your Kubernetes clusters, so that you can detect problems in your systems as early as possible. It kills targeted pods and takes VMs up and down.
+
+Please see the documentation at https://github.com/bloomberg/powerfulseal
+"""
+
 setup(
     name='powerfulseal',
     version='2.6.0',
@@ -13,7 +19,7 @@ setup(
     packages=find_packages(),
     license=read('LICENSE'),
     description='PowerfulSeal - a powerful testing tool for Kubernetes clusters',
-    long_description=read('README.md'),
+    long_description=long_description,
     #long_description_content_type="text/markdown",
     install_requires=[
         'ConfigArgParse>=0.11.0,<1',


### PR DESCRIPTION
This is when I give up, and stop trying to use the full-featured, markdown `README.md`, and just put a shorter version in `setup.py`.

```
NOTE: Try --verbose to see response content.
HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/
PyPI upload failed.
```