### PR TITLE
Improve PyPI publishing process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,10 @@ deploy:
       tags: true
       python: "3.6"
       condition: -n "$DOCKER_PASSWORD"
-  - provider: pypi
-    user: "$PYPI_USER"
-    password: "$PYPI_PASSWORD"
+  - provider: script
+    script:  python -m pip install tox && tox -vve pypi_publish
     skip_cleanup: true
     on:
       tags: true
       python: "3.6"
-      condition: -n "$PYPI_PASSWORD"
+      condition: -n "$TWINE_PASSWORD"

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,14 @@ envlist = py27,py34,py36,py37
 deps = pbr
 extras = testing
 commands = python -m pytest --ignore=./powerfulseal/web/ui
+
+[testenv:pypi_publish]
+changedir = {toxinidir}
+description = Upload a new package to PyPI
+basepython = python3.6
+deps = twine >= 1.12.1
+       pep517
+passenv = TWINE_PASSWORD
+skip_install = true
+commands = python -m pep517.build -s -b . -o {envtmpdir}
+           twine upload --verbose -u __token__ {envtmpdir}/*


### PR DESCRIPTION
This patch changes the PyPI publishing process:

* Uses `pep517` and `twine` for building package and uploading
* Uses TWINE_PASSWORD (no username) instead of PYPI_USER and PYPI_PASSWORD
* Uses a `tox` environment to run the publishing steps

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>
