### PR TITLE
Revert restructuredtext changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ branches:
   only:
     - master
     - /^\d+\.\d+\.\d+(-\S*)?$/
-    
-# install pandoc
-before_install:
-  - sudo apt-get install pandoc
 
 # command to install dependencies
 install:
@@ -28,7 +24,6 @@ script:
   - make build
   - docker images
   - docker run `make version` --help
-  - pandoc -s README.md -t rst -o README.md
 
 # push images to DockerHub and PyPI on tags
 deploy:

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-long_description = """
-**PowerfulSeal** adds chaos to your Kubernetes clusters, so that you can detect problems in your systems as early as possible. It kills targeted pods and takes VMs up and down.
-
-Please see the documentation at https://github.com/bloomberg/powerfulseal
-"""
-
 setup(
     name='powerfulseal',
     version='2.6.0',
@@ -19,7 +13,7 @@ setup(
     packages=find_packages(),
     license=read('LICENSE'),
     description='PowerfulSeal - a powerful testing tool for Kubernetes clusters',
-    long_description=long_description,
+    long_description=read('README.md'),
     #long_description_content_type="text/markdown",
     install_requires=[
         'ConfigArgParse>=0.11.0,<1',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license=read('LICENSE'),
     description='PowerfulSeal - a powerful testing tool for Kubernetes clusters',
     long_description=read('README.md'),
-    #long_description_content_type="text/markdown",
+    long_description_content_type="text/markdown",
     install_requires=[
         'ConfigArgParse>=0.11.0,<1',
         'Flask>=1.0.0,<2',


### PR DESCRIPTION
Following https://github.com/bloomberg/powerfulseal/pull/168, it should now be safe to remove the hacks around not being able to use Markdown in the `long_description` field