### PR TITLE
Add PEP-517 build metadata and other cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
-#  - "3.7"
+  - "3.7"
 
 # enable docker in Travis
 services:
@@ -32,12 +31,12 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      python: "3.6"
+      python: "3.7"
       condition: -n "$DOCKER_PASSWORD"
   - provider: script
     script:  python -m pip install tox && tox -vve pypi_publish
     skip_cleanup: true
     on:
       tags: true
-      python: "3.6"
+      python: "3.7"
       condition: -n "$TWINE_PASSWORD"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ METRICS_SERVER_URL ?= http://metrics-server.kube-system.svc.kubernetes.cluster/
 CLOUD_OPTION ?= --openstack
 
 name ?= powerfulseal
-version ?= `python setup.py --version`
+version ?= `python setup.py --version | sed "s/\+/./"`
 tag = $(name):$(version)
 namespace ?= "bloomberg/"
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ METRICS_SERVER_URL ?= http://metrics-server.kube-system.svc.kubernetes.cluster/
 CLOUD_OPTION ?= --openstack
 
 name ?= powerfulseal
-version ?= `python setup.py --version | sed "s/\+/./"`
+version ?= `python setup.py --version`
 tag = $(name):$(version)
 namespace ?= "bloomberg/"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools >= 40.0.4",
+    "setuptools_scm >= 2.0.0, <4",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools >= 40.0.4",
-    "setuptools_scm >= 2.0.0, <4",
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.7.0',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    use_scm_version=True,
-    setup_requires=['setuptools_scm'],
+    version='2.7.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py36,py37
+envlist = py36,py37
 
 [testenv]
 ; Install pbr (a dependency of os-service-types) in advance to skip os-service-types
@@ -12,7 +12,7 @@ commands = python -m pytest --ignore=./powerfulseal/web/ui
 [testenv:pypi_publish]
 changedir = {toxinidir}
 description = Upload a new package to PyPI
-basepython = python3.6
+basepython = python3.7
 deps = twine >= 1.12.1
        pep517
 passenv = TWINE_PASSWORD


### PR DESCRIPTION
* Add pyproject.toml so that pep517.build can build the package
* Remove Travis-CI testing for Python 2.7 as setup.py requires Python >= 3
* Add Travis-CI test for Python 3.7 and make 3.7 the base for packaging steps

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>
