### PR TITLE
Don't start prometheus http metrics server, if running with Flask debug reloader

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -577,14 +577,19 @@ def main(argv):
     ##########################################################################
     metric_collector = StdoutCollector()
     if args.prometheus_collector:
-        logger.info("Starting prometheus metrics server on %s", args.prometheus_port)
-        start_http_server(args.prometheus_port, args.prometheus_host)
-        metric_collector = PrometheusCollector()
+        flask_debug = os.environ.get("FLASK_DEBUG")
+        flask_env = os.environ.get("FLASK_ENVIROMENT")
+        if flask_debug is not None or (flask_env is not None and flask_env != "production"):
+            logger.error("PROMETHEUS METRICS NOT SUPPORTED WHEN USING FLASK RELOAD. NOT STARTING THE SERVER")
+        else:
+            logger.info("Starting prometheus metrics server on %s", args.prometheus_port)
+            start_http_server(args.prometheus_port, args.prometheus_host)
+            metric_collector = PrometheusCollector()
     elif args.datadog_collector:
         logger.info("Starting datadog collector")
         metric_collector = DatadogCollector()
     else:
-        logger.info("Not starting prometheus collector")
+        logger.info("Using stdout metrics collector")
 
     ##########################################################################
     # AUTONOMOUS MODE

--- a/powerfulseal/clouddrivers/no_cloud_driver.py
+++ b/powerfulseal/clouddrivers/no_cloud_driver.py
@@ -36,7 +36,7 @@ class NoCloudDriver(AbstractDriver):
     def sync(self):
         """ Noop
         """
-        self.logger.error(
+        self.logger.info(
             MESSAGE_IM_NO_CLOUD_DRIVER, "sync"
         )
 


### PR DESCRIPTION
Instead log a big, red message.

Plus a bonus, downgrade an annoying log message to info from error.

Resolves https://github.com/bloomberg/powerfulseal/issues/179