### PR TITLE
Update the default powerfulseal version

### DIFF
--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: powerfulseal
       containers:
         - name: powerfulseal
-          image: store/bloomberg/powerfulseal:2.5.0
+          image: store/bloomberg/powerfulseal:2.6.0
           args: 
           - autonomous
           - --inventory-kubernetes 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: https://github.com/bloomberg/powerfulseal/issues/192

**Describe your changes**
According to the referenced issue, Powerfulseal supports the `--use-pod-delete-instead-of-ssh-kill` argument starting from 2.6.0 version. Thus, the default version in powerfulseal.yml should be at least 2.6.0 since it uses this argument.

**Testing performed**
I've ran the updated manifests in my test cluster and it works without any error. Also I can confirm that it kill pods according to the defined default policy.

Resolves #192