### PR TITLE
fix prometheus issue on kubernetes

### DIFF
--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: powerfulseal
       containers:
         - name: powerfulseal
-          image: store/bloomberg/powerfulseal:2.6.0
+          image: store/bloomberg/powerfulseal:2.8.0
           args: 
           - autonomous
           - --inventory-kubernetes 


### PR DESCRIPTION
For some reason 2.6.0 did not report metrics correctly, leaving metrics empty even though the seal was running amok every 30 seconds:
```
sh-4.2# curl http://172.30.215.58:8081/metrics
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 374808576.0
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 129613824.0
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1579022561.59
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 563.8399999999999
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 10.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1048576.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="7",patchlevel="4",version="3.7.4"} 1.0
# HELP seal_pod_kills_total Number of pods killed (including failures)
# TYPE seal_pod_kills_total counter
# HELP seal_nodes_stopped_total Number of nodes stopped (including failures)
# TYPE seal_nodes_stopped_total counter
# HELP seal_execute_failed_total Increasing counter for command execution failures
# TYPE seal_execute_failed_total counter
# HELP seal_empty_filter_total Increasing counter for cases where filtering returns an empty result
# TYPE seal_empty_filter_total counter
seal_empty_filter_total 0.0
# HELP seal_probability_filter_not_passed_total Increasing counter for cases where the probability filter does not pass any nodes
# TYPE seal_probability_filter_not_passed_total counter
seal_probability_filter_not_passed_total 0.0
# HELP seal_empty_match_total Increasing counter for cases where matching returns an empty result
# TYPE seal_empty_match_total counter
seal_empty_match_total{source="nodes"} 0.0
seal_empty_match_total{source="pods"} 0.0
```

Going to powerfulseal 2.8.0 fixed this issue, so better to have the kubernetes example with this version so others don't have to troubleshoot the same...