### PR TITLE
Shortcut processing scenario if no matched or filtered items

### DIFF
--- a/powerfulseal/policy/scenario.py
+++ b/powerfulseal/policy/scenario.py
@@ -59,10 +59,12 @@ class Scenario():
         initial_set = self.match()
         self.logger.debug("Initial set: %r", initial_set)
         self.logger.info("Initial set length: %d", len(initial_set))
-        filtered_set = self.filter(initial_set)
-        self.logger.debug("Filtered set: %r", filtered_set)
-        self.logger.info("Filtered set length: %d", len(filtered_set))
-        self.act(filtered_set)
+        if initial_set:
+            filtered_set = self.filter(initial_set)
+            self.logger.debug("Filtered set: %r", filtered_set)
+            self.logger.info("Filtered set length: %d", len(filtered_set))
+            if filtered_set:
+                self.act(filtered_set)
         self.logger.debug("Done")
 
     @abc.abstractmethod

--- a/powerfulseal/policy/scenario.py
+++ b/powerfulseal/policy/scenario.py
@@ -65,6 +65,8 @@ class Scenario():
             self.logger.info("Filtered set length: %d", len(filtered_set))
             if filtered_set:
                 self.act(filtered_set)
+        else:
+            self.metric_collector.add_filtered_to_empty_set_metric()
         self.logger.debug("Done")
 
     @abc.abstractmethod

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -33,21 +33,29 @@ def dummy_object():
 
 
 # Scenario fixtures
-class NoopScenario(Scenario):
-
-    def match(self):
-        return []
-
-    def act(self, items):
-        pass
-
-
 @pytest.fixture
 def noop_scenario():
-    return NoopScenario(
+    scenario = Scenario(
         name="test scenario",
         schema={}
     )
+    scenario.match = MagicMock(return_value=[])
+    scenario.filter = MagicMock(return_value=[])
+    scenario.act = MagicMock()
+    return scenario
+
+
+@pytest.fixture
+def no_filtered_items_scenario():
+    scenario = Scenario(
+        name="test scenario",
+        schema={}
+    )
+    matched_items = [ make_dummy_object() ]
+    scenario.match = MagicMock(return_value=matched_items)
+    scenario.filter = MagicMock(return_value=[])
+    scenario.act = MagicMock()
+    return scenario
 
 
 # Pod Scenario Fixtures

--- a/tests/policy/test_scenario.py
+++ b/tests/policy/test_scenario.py
@@ -21,7 +21,7 @@ from mock import MagicMock
 import pytest
 
 # noinspection PyUnresolvedReferences
-from tests.fixtures import noop_scenario
+from tests.fixtures import noop_scenario, no_filtered_items_scenario
 from tests.fixtures import make_dummy_object, dummy_object
 
 
@@ -41,6 +41,18 @@ def test_matches_list_types(noop_scenario, dummy_object, query, should_match):
         "value": query,
     }
     assert should_match == noop_scenario.match_property(dummy_object, criterion)
+
+
+def test_no_matched_items(noop_scenario):
+    noop_scenario.execute()
+    noop_scenario.filter.assert_not_called()
+    noop_scenario.act.assert_not_called()
+
+
+def test_no_filtered_items(no_filtered_items_scenario):
+    no_filtered_items_scenario.execute()
+    no_filtered_items_scenario.filter.assert_called()
+    no_filtered_items_scenario.act.assert_not_called()
 
 
 def test_filter_property(noop_scenario):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #204*

**Describe your changes**
When executing a scenario, if there were no matched items or no filtered items, then don't continue executing the scenario.

If there were no matched items, then also ensure that the metrics are updated.

**Testing performed**
Added unit test to ensure that no further processing of a scenario occurs if there were no matched items.
Added unit test to ensure that no further processing of a scenario occurs if there were no filtered items.

**Additional context**
n/a

Resolves https://github.com/bloomberg/powerfulseal/issues/204