### PR TITLE
lazy load cache of netinterface objects to reduce azure api thrashing

### DIFF
--- a/powerfulseal/clouddrivers/azure_driver.py
+++ b/powerfulseal/clouddrivers/azure_driver.py
@@ -38,40 +38,6 @@ def create_connection_from_config():
 
     return resource_client, compute_client, network_client
 
-def get_all_ips(instance, network_client):
-    """ Returns the private and public ip addresses of an Azure instances
-    """
-    output = []
-    for interface in instance.network_profile.network_interfaces:
-        if_name=" ".join(interface.id.split('/')[-1:])
-        rg="".join(interface.id.split('/')[4])
-
-        try:
-            thing=network_client.network_interfaces.get(rg, if_name).ip_configurations
-            for x in thing:
-                private_ip=x.private_ip_address
-                public_ip=None
-                """print('\nifdata: ',rg,if_name,x.private_ip_address,x.public_ip_address)"""
-                """ Have to extract public IP from public IP class structure...if present """
-                if x.public_ip_address is not None:
-                    public_ip_id=x.public_ip_address.id
-                    public_ip_name=" ".join(public_ip_id.split('/')[-1:])
-                    try:
-                        public_ip_return = network_client.public_ip_addresses.get(rg, public_ip_name)
-                        public_ip=public_ip_return.ip_address
-                    except:
-                        """ Ignore the exception.  return no additional values """
-                        pass
-
-                temp_pair = (private_ip, public_ip)
-                output.append(temp_pair)
-
-        except Exception as e:
-            """ Ignore the exception.  return no additional values """
-            pass
-
-    return output
-
 def server_state(compute_client, server):
     ret_state=NodeState.UNKNOWN
     try:
@@ -109,6 +75,46 @@ class AzureDriver(AbstractDriver):
         self.remote_servers = []
         self.cluster_rg = cluster_rg_name
         self.cluster_node_rg = cluster_node_rg_name
+        self.ipconfig_cache = {}
+
+    def get_all_ips(self, instance, network_client):
+        """ Returns the private and public ip addresses of an Azure instances
+        """
+        output = []
+        for interface in instance.network_profile.network_interfaces:
+            if_name = " ".join(interface.id.split('/')[-1:])
+            rg = "".join(interface.id.split('/')[4])
+
+            try:
+                thing = self.ipconfig_cache.get(if_name)
+                if thing is None:
+                    thing = network_client.network_interfaces.get(
+                        rg, if_name).ip_configurations
+                    self.ipconfig_cache[if_name] = thing
+                for x in thing:
+                    private_ip = x.private_ip_address
+                    public_ip = None
+                    """print('\nifdata: ',rg,if_name,x.private_ip_address,x.public_ip_address)"""
+                    """ Have to extract public IP from public IP class structure...if present """
+                    if x.public_ip_address is not None:
+                        public_ip_id = x.public_ip_address.id
+                        public_ip_name = " ".join(public_ip_id.split('/')[-1:])
+                        try:
+                            public_ip_return = network_client.public_ip_addresses.get(
+                                rg, public_ip_name)
+                            public_ip = public_ip_return.ip_address
+                        except:
+                            """ Ignore the exception.  return no additional values """
+                            pass
+
+                    temp_pair = (private_ip, public_ip)
+                    output.append(temp_pair)
+
+            except Exception as e:
+                """ Ignore the exception.  return no additional values """
+                pass
+
+        return output
 
     def getResourceGroups(self):
         """ Find nodeResourceGroup for the cluster.
@@ -162,7 +168,7 @@ class AzureDriver(AbstractDriver):
         """ Retrieve an instance of Node by its IP.
         """
         for server in self.remote_servers:
-            addresses = get_all_ips(server, self.network_client)
+            addresses = self.get_all_ips(server, self.network_client)
             if not addresses:
                 self.logger.warning("No ip addresses found: %s", server.__dict__)
             else:


### PR DESCRIPTION
**Describe your changes**
For large node count azure AKS clusters the azure driver was taking a very long time (10s of minutes) to build the node inventory. Looks like for every group it would re-fetch network interface objects through the azure API for every node.

I added a simple lazy load cache of network interface objects based on resource name (nic resource).

**Testing performed**
Did development testing against our different AKS cluster sizes to validate no regressions and can now run.

