### PR TITLE
Issue #209 fix (#2)

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -445,7 +445,7 @@ def main(argv):
         if PolicyRunner.is_policy_valid(policy):
             return print('OK')
         print("Policy not valid. See log output above.")
-        return os.exit(1)
+        return sys.exit(1)
 
     ##########################################################################
     # LOGGING
@@ -599,8 +599,8 @@ def main(argv):
         # read and validate the policy
         policy = PolicyRunner.load_file(args.policy_file)
         if not PolicyRunner.is_policy_valid(policy):
-            logger.info("Policy not valid. See log output above.")
-            return os.exit(1)
+            logger.error("Policy not valid. See log output above.")
+            return sys.exit(1)
 
         # run the metrics server if requested
         if not args.headless:
@@ -661,7 +661,7 @@ def main(argv):
         aggressiveness = int(args.aggressiveness)
         if not 1 <= aggressiveness <= 5:
             print("Aggressiveness must be between 1 and 5 inclusive")
-            os.exit(1)
+            sys.exit(1)
 
         metrics_server_client = MetricsServerClient(args.metrics_server_path)
         demo_runner = DemoRunner(

--- a/powerfulseal/policy/policy_runner.py
+++ b/powerfulseal/policy/policy_runner.py
@@ -49,7 +49,7 @@ class PolicyRunner():
         try:
             jsonschema.validate(policy, schema)
         except jsonschema.ValidationError as error:
-            logger.info(error)
+            logger.error(error)
             return False
         return True
 


### PR DESCRIPTION
Signed-off-by: Chris Stanaway <chris.stanaway@here.com>

*Issue number of the reported bug or feature request: #209*

**Describe your changes**
- When policy fails validation, log an error (not info) message.
- When exiting, call `sys.exit()`, not the non-existent `os.exit()`.

**Testing performed**
Ran seal and provided a malformed policy file.  Got expected error output.
Ran seal without malformed policy and worked as expected.

**Additional context**
None.

Fixes #209 