### PR TITLE
Remove the check for not building the CI based on a git diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ branches:
     - master
     - /^\d+\.\d+\.\d+(-\S*)?$/
 
-before_install:
-  - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|^(LICENSE)|^(docs)'
-      then
-        echo "Only doc files were updated, not running the CI."
-        exit
-      fi
-
 # command to install dependencies
 install:
   - pip install tox tox-travis -U --force-reinstall

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.0.0
+version = 3.0.0rc0
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters


### PR DESCRIPTION
It initially looked like a good idea, but will be hard to maintain.
It breaks the tag building workflow.