### PR TITLE
Support per-probe proxies, by default use no proxies, regardless of the ENV

### DIFF
--- a/docs/2_getting-started.md
+++ b/docs/2_getting-started.md
@@ -85,7 +85,7 @@ For help, just type `help`. For more information about the modes, see our [docs 
 For each [release](https://github.com/bloomberg/powerfulseal/releases) a `docker` image is built and published to the [docker hub](https://hub.docker.com/_/powerfulseal).
 
 ```sh
-docker pull store/bloomberg/powerfulseal:3.0.0rc0
+docker pull store/bloomberg/powerfulseal:3.0.0rc1
 ```
 
 ### Run docker image

--- a/docs/policies/http-proxy.md
+++ b/docs/policies/http-proxy.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: Different proxies for probes
+description: ""
+permalink: /http-proxy-http_proxy 
+parent: Writing policies
+nav_order: 7
+---
+
+# Different proxies for probes
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Scenario
+
+Sometimes you need different proxies for different HTTP probes.
+
+
+## Scenario
+
+```yaml
+scenarios:
+- name: Proxies
+  steps:
+
+  # no proxies needed in cluster
+  - probeHTTP:
+      target:
+        service:
+          name: myservice
+          namespace: example
+          port: 8000
+
+  # for this url, we need a special proxy
+  - probeHTTP:
+      target:
+        url: https://something.somewhere.com
+      proxy: http://some-proxy:8080
+
+  # note, that this will ignore HTTP_PROXY and HTTPS_PROXY in the env
+  # at will go without proxies
+  - probeHTTP:
+      target:
+        url: https://something.somewhere.com
+
+```

--- a/docs/policies/kubectl.md
+++ b/docs/policies/kubectl.md
@@ -66,7 +66,7 @@ scenarios:
             spec:
               containers:
                 - name: powerfulseal
-                  image: store/bloomberg/powerfulseal:3.0.0rc0
+                  image: store/bloomberg/powerfulseal:3.0.0rc1
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/docs/schema/index.html
+++ b/docs/schema/index.html
@@ -430,6 +430,25 @@
               </div>
             </div>
         </div>
+    </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option1__probeHTTP__proxy">
+        <div class="card">
+            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option1__probeHTTP__proxy">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option1__probeHTTP__proxy"
+                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option1__probeHTTP__proxy" onclick="setAnchor('#scenarios_array_items__steps_array_items__option1__probeHTTP__proxy')"><span class="property-name">proxy</span></button>
+                </h2>
+            </div>
+
+            <div id="scenarios_array_items__steps_array_items__option1__probeHTTP__proxy"
+                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option1__probeHTTP__proxy"
+                 data-parent="#accordionscenarios_array_items__steps_array_items__option1__probeHTTP__proxy">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: string</span><span class="description"><p>Proxy to use with the requests. If not set no proxy will be used. NOTE, that the probe ignores (and overrides) HTTP{S}_PROXY envvars.</p>
+</span>
+
+            
+              </div>
+            </div>
+        </div>
     </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option1__probeHTTP__retries">
         <div class="card">
             <div class="card-header" id="headingscenarios_array_items__steps_array_items__option1__probeHTTP__retries">

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: powerfulseal
       containers:
         - name: powerfulseal
-          image: store/bloomberg/powerfulseal:3.0.0rc0
+          image: store/bloomberg/powerfulseal:3.0.0rc1
           args:
           - autonomous
           - --policy-file=/policy.yml

--- a/powerfulseal/cli/pscmd.py
+++ b/powerfulseal/cli/pscmd.py
@@ -437,8 +437,8 @@ class PSCmd(cmd.Cmd):
                 break
         if pod is None:
             return print("Pod number not found.")
-        if pod.state == 'Pending':
-            return print("Can't kill pod on pending state")
+        if pod.state.lower() != 'running':
+            return print("Can't kill pod with state", pod.state)
 
         # check with the user
         ans = False

--- a/powerfulseal/policy/action_probe_http.py
+++ b/powerfulseal/policy/action_probe_http.py
@@ -73,7 +73,7 @@ class ActionProbeHTTP(ActionAbstract):
             headers[header["name"]] = header["value"]
         return headers
 
-    def make_call(self, url, method, body, headers, timeout, code):
+    def make_call(self, url, method, body, headers, timeout, code, proxy):
         self.logger.info(
             "Making a call: %s, %s, %r, %d, %d, %s",
             url, method, headers, timeout, code, body
@@ -85,6 +85,10 @@ class ActionProbeHTTP(ActionAbstract):
                 headers=headers,
                 timeout=timeout/1000,
                 data=body.encode("utf-8"),
+                proxies=dict(
+                    http=proxy or "",
+                    https=proxy or "",
+                ),
             )
             resp.raise_for_status()
             self.logger.info("Response: %s", resp.text)
@@ -104,6 +108,7 @@ class ActionProbeHTTP(ActionAbstract):
         body = self.schema.get("body", "")
         timeout = self.schema.get("timeout", 1000)
         code = self.schema.get("code", 200)
+        proxy = self.schema.get("proxy", "")
 
         for _ in range(count):
             for retry in range(retries):
@@ -114,6 +119,7 @@ class ActionProbeHTTP(ActionAbstract):
                     headers=headers,
                     timeout=timeout,
                     code=code,
+                    proxy=proxy,
                 )
                 if not success:
                     # if we've reached the limit, the answer is no

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -324,6 +324,12 @@ definitions:
                   type: string
                 value:
                   type: string
+          proxy:
+            type: string
+            description: >
+              Proxy to use with the requests.
+              If not set no proxy will be used.
+              NOTE, that the probe ignores (and overrides) HTTP{S}_PROXY envvars.
         required:
         - target
     required:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.0.0rc0
+version = 3.0.0rc1
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -63,7 +63,7 @@ scenarios:
               serviceAccountName: powerfulseal
               containers:
                 - name: powerfulseal
-                  image: store/bloomberg/powerfulseal:3.0.0rc0
+                  image: store/bloomberg/powerfulseal:3.0.0rc1
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/tests/policy/test_action_probe_http.py
+++ b/tests/policy/test_action_probe_http.py
@@ -78,3 +78,21 @@ def test_get_url_all_params(action_probe_http):
     args = mock_request.call_args
     assert args.args == ('POST', 'http://10.10.10.10:80/')
     assert args.kwargs == dict(headers={'TEST': 'SOMETHING'}, timeout=2.0, data=b'SOMEBODY here!', proxies={'http': '', 'https': ''})
+
+def test_get_url_proxy(action_probe_http):
+    schema = dict(
+        target=dict(
+            url="http://10.10.10.10:80"
+        ),
+        proxy="http://some.proxy.com:8080"
+    )
+    action_probe_http.schema = schema
+    mock_request = MagicMock()
+
+    with patch("requests.request", mock_request):
+        action_probe_http.execute()
+
+    assert mock_request.call_count == 1
+    args = mock_request.call_args
+    assert args.args == ('GET', 'http://10.10.10.10:80/')
+    assert args.kwargs == dict(headers={}, timeout=1.0, data=b'', proxies={'http': "http://some.proxy.com:8080", 'https': "http://some.proxy.com:8080"})

--- a/tests/policy/test_action_probe_http.py
+++ b/tests/policy/test_action_probe_http.py
@@ -77,4 +77,4 @@ def test_get_url_all_params(action_probe_http):
     assert mock_request.call_count == 1
     args = mock_request.call_args
     assert args.args == ('POST', 'http://10.10.10.10:80/')
-    assert args.kwargs == dict(headers={'TEST': 'SOMETHING'}, timeout=2.0, data=b'SOMEBODY here!')
+    assert args.kwargs == dict(headers={'TEST': 'SOMETHING'}, timeout=2.0, data=b'SOMEBODY here!', proxies={'http': '', 'https': ''})


### PR DESCRIPTION
If you need different proxies for different probes, you're going to like this.