### PR TITLE
Kubectl proxy, fix docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,3 @@ powerfulseal.egg-info
 # virtualenv
 env
 # non-code
-docs

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,6 +16,7 @@ ARG no_proxy
 WORKDIR /powerfulseal
 COPY Makefile LICENSE README.md setup.py setup.cfg MANIFEST.in /powerfulseal/
 COPY powerfulseal/ /powerfulseal/powerfulseal/
+COPY docs/schema/ /powerfulseal/docs/schema/
 
 # install it with pip
 RUN pip install . && pip list .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@ ARG no_proxy
 WORKDIR /powerfulseal
 COPY Makefile LICENSE README.md setup.py setup.cfg MANIFEST.in /powerfulseal/
 COPY powerfulseal/ /powerfulseal/powerfulseal/
-COPY docs/schema/ /powerfulseal/docs/schema/
+COPY docs/ /powerfulseal/docs/
 
 # install it with pip
 RUN pip install . && pip list .

--- a/docs/2_getting-started.md
+++ b/docs/2_getting-started.md
@@ -85,7 +85,7 @@ For help, just type `help`. For more information about the modes, see our [docs 
 For each [release](https://github.com/bloomberg/powerfulseal/releases) a `docker` image is built and published to the [docker hub](https://hub.docker.com/_/powerfulseal).
 
 ```sh
-docker pull store/bloomberg/powerfulseal:3.0.0rc3
+docker pull store/bloomberg/powerfulseal:3.0.0rc4
 ```
 
 ### Run docker image

--- a/docs/5_setup.md
+++ b/docs/5_setup.md
@@ -50,6 +50,32 @@ If you're running outside of your cluster, the setup will involve:
 It should look something like [this](https://github.com/bloomberg/powerfulseal/blob/master/docs/media/setup.png).
 
 
+## Kubectl
+
+The `powerfulseal` image packages a `kubectl` binary to execute the `kubectl` actions with.
+When executing the commands, the `http{s}_proxy` variables are overwritten by the contents of the `proxy` parameter from inside of the scenario.
+
+If you exec into the pod, you can `kubectl` directly, using the same RBAC permissions.
+
+For example, in the [./kubernetes](https://github.com/bloomberg/powerfulseal/tree/master/kubernetes) contains RBAC which allows the seal to:
+
+- read from all namespaces
+- delete pods in all namespaces
+- do everything inside of the special `powerfulseal-sandbox` namespace
+  - all creation of new pods will need to happen inside of that namespace
+
+
+### `kubectl` action permissions
+
+Remember, that in order to be able to execute the `kubectl` action payloads, you're going to need to give you pod necessary permissions.
+
+
+
+## Exec-ing into a running pod
+
+If you have a running `powerfulseal` pod executing scenario, you can always `kubectl exec -ti ps-pod -- bash` and then run `powerfulseal interactive` from inside of it.
+
+
 ## Cloud drivers
 
 In order to interact with VMs, you're going to need to configure a cloud driver. [Learn more](./cloud-provider-requirements)

--- a/docs/policies/kubectl.md
+++ b/docs/policies/kubectl.md
@@ -66,7 +66,7 @@ scenarios:
             spec:
               containers:
                 - name: powerfulseal
-                  image: store/bloomberg/powerfulseal:3.0.0rc3
+                  image: store/bloomberg/powerfulseal:3.0.0rc4
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/docs/schema/index.html
+++ b/docs/schema/index.html
@@ -724,6 +724,25 @@
               </div>
             </div>
         </div>
+    </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary">
+        <div class="card">
+            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary"
+                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary" onclick="setAnchor('#scenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary')"><span class="property-name">kubectlBinary</span></button>
+                </h2>
+            </div>
+
+            <div id="scenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary"
+                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary"
+                 data-parent="#accordionscenarios_array_items__steps_array_items__option2__kubectl__kubectlBinary">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: string</span> <span class="badge badge-success default-value">Default: "kubectl"</span><span class="description"><p>The path to the binary of kubectl.</p>
+</span>
+
+            
+              </div>
+            </div>
+        </div>
     </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option2__kubectl__payload">
         <div class="card">
             <div class="card-header" id="headingscenarios_array_items__steps_array_items__option2__kubectl__payload">
@@ -737,6 +756,25 @@
                  data-parent="#accordionscenarios_array_items__steps_array_items__option2__kubectl__payload">
               <div class="card-body">
                 <span class="badge badge-dark value-type">Type: string</span><span class="description"><p>Free-form, kubectl-compatible payload, which will be passed to kubectl as is.</p>
+</span>
+
+            
+              </div>
+            </div>
+        </div>
+    </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option2__kubectl__proxy">
+        <div class="card">
+            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option2__kubectl__proxy">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option2__kubectl__proxy"
+                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option2__kubectl__proxy" onclick="setAnchor('#scenarios_array_items__steps_array_items__option2__kubectl__proxy')"><span class="property-name">proxy</span></button>
+                </h2>
+            </div>
+
+            <div id="scenarios_array_items__steps_array_items__option2__kubectl__proxy"
+                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option2__kubectl__proxy"
+                 data-parent="#accordionscenarios_array_items__steps_array_items__option2__kubectl__proxy">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: string</span> <span class="badge badge-success default-value">Default: ""</span><span class="description"><p>Proxy to use with the kubectl command. If not set no proxy will be used. NOTE, that the probe ignores (and overrides) HTTP{S}_PROXY envvars.</p>
 </span>
 
             

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sealpolicy
+  namespace: powerfulseal
 data:
   policy.yml: |-
     scenarios:
@@ -24,6 +25,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: powerfulseal
+  namespace: powerfulseal
 spec:
   replicas: 1
   template:

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: powerfulseal
       containers:
         - name: powerfulseal
-          image: store/bloomberg/powerfulseal:3.0.0rc3
+          image: store/bloomberg/powerfulseal:3.0.0rc4
           args:
           - autonomous
           - --policy-file=/policy.yml

--- a/kubernetes/rbac.yml
+++ b/kubernetes/rbac.yml
@@ -1,10 +1,26 @@
 ---
+# this is the namespace where the powerfulseal will live
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: powerfulseal
+---
+# this is the namespace where powerfulseal will create things
+# it will have full power over this namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: powerfulseal-sandbox
+
+# the service account to read from all namespaces
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    app: powerfulseal
   name: powerfulseal
+  namespace: powerfulseal
+
+# cluster role to read things and delete pods in all namespaces
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -23,22 +39,65 @@ rules:
   - ""
   resources:
   - nodes
-  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - namespaces
+  - deployments
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "apps"
+  resources:
   - deployments
   verbs:
   - get
   - list
+# bind the cluster role to the service account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: powerfulseal
+subjects:
+  - kind: ServiceAccount
+    name: powerfulseal
+    namespace: powerfulseal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: powerfulseal
+
+# role to do all and anything in powerfulseal-sandbox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: powerfulseal-sandbox
+  namespace: powerfulseal-sandbox
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: powerfulseal-sandbox
+  namespace: powerfulseal-sandbox
 subjects:
-- kind: ServiceAccount
-  name: powerfulseal
-  namespace: default
+  - kind: ServiceAccount
+    name: powerfulseal
+    namespace: powerfulseal
+roleRef:
+  kind: Role
+  name: powerfulseal-sandbox
+  apiGroup: rbac.authorization.k8s.io

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -238,6 +238,18 @@ definitions:
             description:
               When set to true, all the `kubectl apply` commands will be `kubectl delete`ed at the end of the scenario.
             default: true
+          proxy:
+            type: string
+            description: >
+              Proxy to use with the kubectl command.
+              If not set no proxy will be used.
+              NOTE, that the probe ignores (and overrides) HTTP{S}_PROXY envvars.
+            default: ""
+          kubectlBinary:
+            type: string
+            description: >
+              The path to the binary of kubectl.
+            default: "kubectl"
         required:
         - action
         - payload

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.0.0rc3
+version = 3.0.0rc4
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -80,6 +80,13 @@ scenarios:
       payload: |
         ---
 
+  - kubectl:
+      action: apply
+      proxy: someproxy.com:8080
+      kubectlBinary: /some/path/binary
+      payload: |
+        ---
+
   # nodeAction performs actions on specific nodes in the cluster
   - nodeAction:
       # Choose the initial set of nodes to operate on.

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -63,7 +63,7 @@ scenarios:
               serviceAccountName: powerfulseal
               containers:
                 - name: powerfulseal
-                  image: store/bloomberg/powerfulseal:3.0.0rc3
+                  image: store/bloomberg/powerfulseal:3.0.0rc4
                   args:
                   - autonomous
                   - --policy-file=/policy.yml


### PR DESCRIPTION
Add support to inject `http{s}_proxy` value for kubectl commands in the schema.

Default to not using the proxies (even if they are in the environement) - this makes it easier to run in pod.