### PR TITLE
Make exit strategy configurable

### DIFF
--- a/docs/4_policies.md
+++ b/docs/4_policies.md
@@ -88,6 +88,19 @@ config:
 scenarios: []
 ```
 
+### Exit strategy
+
+By default, if a scenario fails, the seal will report the error so that you can alert on it, and keep going.
+
+If you'd like it to exit (for example if you're running it as a job), you can use the `fail-fast` exit strategy:
+
+```yaml
+config:
+  exitStrategy:
+    strategy: fail-fast
+scenarios: []
+```
+
 ## Examples
 
 To see examples of policies, use the menu on the left.

--- a/docs/6_in-depth.md
+++ b/docs/6_in-depth.md
@@ -40,6 +40,7 @@ The metric collectors collect the following events:
 | seal_empty_filter_total | N/A | Cases where filtering returns an empty result | If the user's policy is designed to model common levels of failures, then having no nodes/pods after filtering could mean that insufficient resources have been provisioned for the system to withstand failure. |
 | seal_probability_filter_not_passed_total | N/A | Cases where the probability filter decides to skip all nodes | Useful to track long-term in order to ensure that probability distribution is as expected. |
 | seal_empty_match_total | source (either `nodes` or `pods`) | Cases where matching returns an empty result | See `seal_empty_filter_total` |
+| add_scenario_counter_metric | name of the scenario, success or fail | Counts scenarios and their results | Can be used to alert on when a scenario starts failing |
 
 ### Usage
 

--- a/docs/schema/index.html
+++ b/docs/schema/index.html
@@ -29,7 +29,48 @@
                 <span class="badge badge-dark value-type">Type: object</span><span class="description"><p>General configuration of this policy.</p>
 </span>
 
-            <div class="accordion" id="accordionconfig__runStrategy">
+            <div class="accordion" id="accordionconfig__exitStrategy">
+        <div class="card">
+            <div class="card-header" id="headingconfig__exitStrategy">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#config__exitStrategy"
+                            aria-expanded="False" aria-controls="config__exitStrategy" onclick="setAnchor('#config__exitStrategy')"><span class="property-name">exitStrategy</span></button>
+                </h2>
+            </div>
+
+            <div id="config__exitStrategy"
+                 class="collapse property-definition-div" aria-labelledby="headingconfig__exitStrategy"
+                 data-parent="#accordionconfig__exitStrategy">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: object</span><span class="description"><p>Configure how exit is configured</p>
+</span>
+
+            <div class="accordion" id="accordionconfig__exitStrategy__strategy">
+        <div class="card">
+            <div class="card-header" id="headingconfig__exitStrategy__strategy">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#config__exitStrategy__strategy"
+                            aria-expanded="False" aria-controls="config__exitStrategy__strategy" onclick="setAnchor('#config__exitStrategy__strategy')"><span class="property-name">strategy</span></button>
+                </h2>
+            </div>
+
+            <div id="config__exitStrategy__strategy"
+                 class="collapse property-definition-div" aria-labelledby="headingconfig__exitStrategy__strategy"
+                 data-parent="#accordionconfig__exitStrategy__strategy">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: enum (of string)</span> <span class="badge badge-success default-value">Default: "report"</span><span class="description"><p>Affects what PowerfulSeal does when errors occur. The default <code>report</code> logs an error message, updates metrics and carries on. <code>fail-fast</code> fails and exits immediately on first exit (useful when running as a job).</p>
+</span>
+
+            <div class="enum-value" id="config__exitStrategy__strategy_enum">
+                <h4>Must be one of:</h4>
+                <ul class="list-group"><li class="list-group-item">"report"</li><li class="list-group-item">"fail-fast"</li></ul>
+                </div>
+              </div>
+            </div>
+        </div>
+    </div>
+              </div>
+            </div>
+        </div>
+    </div><div class="accordion" id="accordionconfig__runStrategy">
         <div class="card">
             <div class="card-header" id="headingconfig__runStrategy">
                 <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#config__runStrategy"

--- a/powerfulseal/metriccollectors/collector.py
+++ b/powerfulseal/metriccollectors/collector.py
@@ -58,3 +58,7 @@ class AbstractCollector(ABC):
     @abstractmethod
     def add_matched_to_empty_set_metric(self, source):
         pass  # pragma: nocover
+
+    @abstractmethod
+    def add_scenario_counter_metric(self, name, result):
+        pass  # pragma: nocover

--- a/powerfulseal/metriccollectors/datadog_collector.py
+++ b/powerfulseal/metriccollectors/datadog_collector.py
@@ -10,6 +10,8 @@ NODE_STOPS_METRIC_NAME = 'powerfulseal.nodes_stopped_total'
 NODE_STOPS = ['status:', 'id:', 'name:']
 EXECUTE_FAILED_METRIC_NAME = 'powerfulseal.execute_failed_total'
 EXECUTE_FAILURES = ['id:', 'name:']
+SCENARIO_RUNS_METRIC_NAME = 'powerfulseal.scenario_runs_total'
+SCENARIO_RUNS = ['name:', 'result:']
 FILTERED_TO_EMPTY_SET_METRIC_NAME = 'powerfulseal.empty_filter_total'
 PROBABILITY_FILTER_NOT_PASSED_METRIC_NAME = 'powerfulseal.probability_filter_not_passed_total'
 MATCHED_TO_EMPTY_SET_METRIC_NAME = 'powerfulseal.empty_match_total'
@@ -54,3 +56,8 @@ class DatadogCollector(AbstractCollector):
     def add_matched_to_empty_set_metric(self, source):
         statsd.increment(MATCHED_TO_EMPTY_SET_METRIC_NAME,
                          tags=name_tags(MATCHED_TO_EMPTY_SET, [source]))
+
+    def add_scenario_counter_metric(self, name, result):
+        res = "success" if result else "fail"
+        statsd.increment(SCENARIO_RUNS_METRIC_NAME, tags=name_tags(
+            SCENARIO_RUNS, [name, res]))

--- a/powerfulseal/metriccollectors/prometheus_collector.py
+++ b/powerfulseal/metriccollectors/prometheus_collector.py
@@ -94,4 +94,4 @@ class PrometheusCollector(AbstractCollector):
 
     def add_scenario_counter_metric(self, name, result):
         res = "success" if result else "fail"
-        SCENARIO_RUNS_TOTAL.labels(name, name, res).inc()
+        SCENARIO_RUNS_TOTAL.labels(name, res).inc()

--- a/powerfulseal/metriccollectors/prometheus_collector.py
+++ b/powerfulseal/metriccollectors/prometheus_collector.py
@@ -54,6 +54,11 @@ MATCHED_TO_EMPTY_SET = Counter(MATCHED_TO_EMPTY_SET_METRIC_NAME,
                                'returns an empty result',
                                ['source'])
 
+SCENARIO_RUNS_METRIC_NAME = 'seal_scenario_runs_total'
+SCENARIO_RUNS_TOTAL = Counter(SCENARIO_RUNS_METRIC_NAME,
+                           'Counter of runs of scenarios (both success and failure)',
+                           ['name', 'result'])
+
 
 class PrometheusCollector(AbstractCollector):
     def __init__(self):
@@ -86,3 +91,7 @@ class PrometheusCollector(AbstractCollector):
 
     def add_matched_to_empty_set_metric(self, source):
         MATCHED_TO_EMPTY_SET.labels(source).inc()
+
+    def add_scenario_counter_metric(self, name, result):
+        res = "success" if result else "fail"
+        SCENARIO_RUNS_TOTAL.labels(name, name, res).inc()

--- a/powerfulseal/metriccollectors/stdout_collector.py
+++ b/powerfulseal/metriccollectors/stdout_collector.py
@@ -48,3 +48,6 @@ class StdoutCollector(AbstractCollector):
 
     def add_matched_to_empty_set_metric(self, source):
         logger.debug("Matched to empty set - source: %s", source)
+
+    def add_scenario_counter_metric(self, name, result):
+        logger.debug("Scenario %s result: %s", name, result)

--- a/powerfulseal/policy/policy_runner.py
+++ b/powerfulseal/policy/policy_runner.py
@@ -64,6 +64,8 @@ class PolicyRunner():
         wait_min = config.get("minSecondsBetweenRuns", 0)
         wait_max = config.get("maxSecondsBetweenRuns", 300)
         loops = config.get("runs", None)
+        exitConfig = policy.get("config", {}).get("exitStrategy", {})
+        exitStrategy = exitConfig.get("strategy", "report")
         scenarios = [
             Scenario(
                 name=item.get("name"),
@@ -84,8 +86,11 @@ class PolicyRunner():
             for scenario in scenarios:
                 ret = scenario.execute()
                 if not ret:
-                    logger.error("Exiting early")
-                    return False
+                    if exitStrategy == "fail-fast":
+                        logger.error("Exiting early")
+                        return False
+                    else:
+                        logger.error("Scenario failed, reporting and carrying on")
                 sleep_time = int(random.uniform(wait_min, wait_max))
                 logger.info("Sleeping for %s seconds", sleep_time)
                 time.sleep(sleep_time)

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -46,6 +46,9 @@ definitions:
       runStrategy:
         type: object
         "$ref": "#/definitions/runStrategy"
+      exitStrategy:
+        type: object
+        "$ref": "#/definitions/exitStrategy"
 
   runStrategy:
     description: "Configure how the scenarios are run"
@@ -81,6 +84,22 @@ definitions:
         type: number
         minimum: 0
         default: 300
+
+  exitStrategy:
+    description: "Configure how exit is configured"
+    type: object
+    additionalProperties: false
+    properties:
+      strategy:
+        type: string
+        description: >
+          Affects what PowerfulSeal does when errors occur.
+          The default `report` logs an error message, updates metrics and carries on.
+          `fail-fast` fails and exits immediately on first exit (useful when running as a job).
+        default: report
+        enum:
+        - report
+        - fail-fast
 
   scenario:
     description: >

--- a/powerfulseal/policy/scenario.py
+++ b/powerfulseal/policy/scenario.py
@@ -60,9 +60,11 @@ class Scenario():
                     ret = action_method(schema=step.get(action_name))
                     if not ret:
                         self.logger.warning("Step returned failure %s. Finishing scenario early", step)
+                        self.metric_collector.add_scenario_counter_metric(self.name, False)
                         self.cleanup()
                         return False
         self.logger.info("Scenario finished")
+        self.metric_collector.add_scenario_counter_metric(self.name, True)
         self.cleanup()
         return True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.0.0rc8
+version = 3.0.0rc9
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -6,6 +6,9 @@ config:
     minSecondsBetweenRuns: 77
     maxSecondsBetweenRuns: 78
 
+  exitStrategy:
+    strategy: fail-fast
+
 # scenarios is an array of chaos experiment descriptions
 scenarios:
 


### PR DESCRIPTION
Resolves https://github.com/bloomberg/powerfulseal/issues/253

It produces metrics like these:

```prometheus
# HELP seal_scenario_runs_total Counter of runs of scenarios (both success and failure)
# TYPE seal_scenario_runs_total counter
seal_scenario_runs_total{name="wait some",result="success"} 4.0
seal_scenario_runs_total{name="probe some stuff",result="fail"} 3.0
seal_scenario_runs_total{name="delete a random pod in default namespace",result="success"} 3.0
seal_scenario_runs_total{name="Count some pods",result="fail"} 3.0
```