### PR TITLE
Update all references to use the regular docker registry, not the store

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,8 @@ powerfulseal autonomous --policy-file ./policy.yaml
 
 ## Installing
 
-
-- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `pip install powerfulseal`
-- [pip](https://pypi.org/project/powerfulseal/): `docker pull bloomberg/powerfulseal:3.0.0rc9`
+- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `docker pull bloomberg/powerfulseal:3.0.0rc9`
+- [pip](https://pypi.org/project/powerfulseal/): `pip install powerfulseal`
 
 
 ## Read about the PowerfulSeal

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ powerfulseal autonomous --policy-file ./policy.yaml
 
 [Learn more](https://bloomberg.github.io/powerfulseal)
 
+## Installing
+
+
+- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `pip install powerfulseal`
+- [pip](https://pypi.org/project/powerfulseal/): `docker pull bloomberg/powerfulseal:3.0.0rc9`
+
 
 ## Read about the PowerfulSeal
 

--- a/docs/2_getting-started.md
+++ b/docs/2_getting-started.md
@@ -82,10 +82,10 @@ For help, just type `help`. For more information about the modes, see our [docs 
 
 ### Download docker image
 
-For each [release](https://github.com/bloomberg/powerfulseal/releases) a `docker` image is built and published to the [docker hub](https://hub.docker.com/_/powerfulseal).
+For each [release](https://github.com/bloomberg/powerfulseal/releases) a `docker` image is built and published to the [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags).
 
 ```sh
-docker pull store/bloomberg/powerfulseal:3.0.0rc8
+docker pull bloomberg/powerfulseal:3.0.0rc9
 ```
 
 ### Run docker image
@@ -97,7 +97,7 @@ Below is an example of using the `-v` flag to inject your local `kubeconfig` to 
 ```sh
 docker run -it \
     -v ~/.kube:/root/.kube \
-    docker.io/store/bloomberg/powerfulseal:2.8.0 \
+    bloomberg/powerfulseal:3.0.0rc9 \
     interactive
 ```
 

--- a/docs/policies/kubectl.md
+++ b/docs/policies/kubectl.md
@@ -66,7 +66,7 @@ scenarios:
             spec:
               containers:
                 - name: powerfulseal
-                  image: store/bloomberg/powerfulseal:3.0.0rc8
+                  image: bloomberg/powerfulseal:3.0.0rc9
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: powerfulseal
       containers:
         - name: powerfulseal
-          image: store/bloomberg/powerfulseal:3.0.0rc8
+          image: bloomberg/powerfulseal:3.0.0rc9
           args:
           - autonomous
           - --policy-file=/policy.yml

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -66,7 +66,7 @@ scenarios:
               serviceAccountName: powerfulseal
               containers:
                 - name: powerfulseal
-                  image: store/bloomberg/powerfulseal:3.0.0rc8
+                  image: bloomberg/powerfulseal:3.0.0rc9
                   args:
                   - autonomous
                   - --policy-file=/policy.yml


### PR DESCRIPTION
The store proved difficult to use - people were confused, and you couldn't see the tags available. This changes all the references to point to the regular docker hub.