### PR TITLE
Add a new podAction: stopHost

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ powerfulseal autonomous --policy-file ./policy.yaml
 
 ## Installing
 
-- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `docker pull bloomberg/powerfulseal:3.0.0rc10`
+- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `docker pull bloomberg/powerfulseal:3.0.0rc11`
 - [pip](https://pypi.org/project/powerfulseal/): `pip install powerfulseal`
 
 

--- a/docs/2_getting-started.md
+++ b/docs/2_getting-started.md
@@ -85,7 +85,7 @@ For help, just type `help`. For more information about the modes, see our [docs 
 For each [release](https://github.com/bloomberg/powerfulseal/releases) a `docker` image is built and published to the [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags).
 
 ```sh
-docker pull bloomberg/powerfulseal:3.0.0rc10
+docker pull bloomberg/powerfulseal:3.0.0rc11
 ```
 
 ### Run docker image
@@ -97,7 +97,7 @@ Below is an example of using the `-v` flag to inject your local `kubeconfig` to 
 ```sh
 docker run -it \
     -v ~/.kube:/root/.kube \
-    bloomberg/powerfulseal:3.0.0rc10 \
+    bloomberg/powerfulseal:3.0.0rc11 \
     interactive
 ```
 

--- a/docs/policies/kubectl.md
+++ b/docs/policies/kubectl.md
@@ -66,7 +66,7 @@ scenarios:
             spec:
               containers:
                 - name: powerfulseal
-                  image: bloomberg/powerfulseal:3.0.0rc10
+                  image: bloomberg/powerfulseal:3.0.0rc11
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/docs/policies/pods-and-hosts.md
+++ b/docs/policies/pods-and-hosts.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: Stop a host running particular pod
+description: ""
+permalink: /stop-host-running-a-pod 
+parent: Writing policies
+nav_order: 8
+---
+
+# Stop a host running particular pod
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Scenario
+
+You might want to stop a host that runs a particular set of pods. You can do that with `stopHost` action for pods.
+
+
+## Scenario
+
+```yaml
+scenarios:
+- name: Stop that host!
+  steps:
+  - podAction:
+      matches:
+        - namespace: something
+      filters:
+        - randomSample:
+            size: 1
+      actions:
+        - stopHost:
+            autoRestart: true
+  - wait:
+      seconds: 30
+
+```
+
+This will stop the host running that pod, and restart at the end of the scenario.

--- a/docs/schema/index.html
+++ b/docs/schema/index.html
@@ -883,6 +883,10 @@
                    id="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option4" data-toggle="tab" href="#tab-pane_scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option4" role="tab"
                    onclick="setAnchor('#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option4')"
                 >Option 4</a>
+            </li><li class="nav-item"><a class="nav-link oneOf-option"
+                   id="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5" data-toggle="tab" href="#tab-pane_scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5" role="tab"
+                   onclick="setAnchor('#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5')"
+                >Option 5</a>
             </li></ul>
     <div class="tab-content card"><div class="tab-pane fade card-body active show"
                  id="tab-pane_scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option1" role="tabpanel"><span class="badge badge-dark value-type">Type: object</span><span class="description"><p>Kill a pod.</p>
@@ -1057,6 +1061,66 @@
                  data-parent="#accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option4__checkPodCount__count">
               <div class="card-body">
                 <span class="badge badge-dark value-type">Type: number</span>
+
+            
+              </div>
+            </div>
+        </div>
+    </div>
+              </div>
+            </div>
+        </div>
+    </div>
+            </div><div class="tab-pane fade card-body "
+                 id="tab-pane_scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5" role="tabpanel"><span class="badge badge-dark value-type">Type: object</span><span class="description"><p>Stops the host on which the pods are running.</p>
+</span>
+
+            <div class="accordion" id="accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost">
+        <div class="card">
+            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost"
+                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost" onclick="setAnchor('#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost')"><span class="property-name">stopHost</span> <span class="badge badge-warning required-property">Required</span></button>
+                </h2>
+            </div>
+
+            <div id="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost"
+                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost"
+                 data-parent="#accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: object</span>
+
+            <div class="accordion" id="accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart">
+        <div class="card">
+            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart"
+                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart" onclick="setAnchor('#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart')"><span class="property-name">autoRestart</span></button>
+                </h2>
+            </div>
+
+            <div id="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart"
+                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart"
+                 data-parent="#accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__autoRestart">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: boolean</span> <span class="badge badge-success default-value">Default: true</span><span class="description"><p>When set to true, the node will be restarted at the end of the scenario.</p>
+</span>
+
+            
+              </div>
+            </div>
+        </div>
+    </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force">
+        <div class="card">
+            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force">
+                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force"
+                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force" onclick="setAnchor('#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force')"><span class="property-name">force</span></button>
+                </h2>
+            </div>
+
+            <div id="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force"
+                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force"
+                 data-parent="#accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force">
+              <div class="card-body">
+                <span class="badge badge-dark value-type">Type: boolean</span>
 
             
               </div>

--- a/docs/schema/index.html
+++ b/docs/schema/index.html
@@ -1108,24 +1108,6 @@
               </div>
             </div>
         </div>
-    </div><div class="accordion" id="accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force">
-        <div class="card">
-            <div class="card-header" id="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force">
-                <h2 class="mb-0"><button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force"
-                            aria-expanded="False" aria-controls="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force" onclick="setAnchor('#scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force')"><span class="property-name">force</span></button>
-                </h2>
-            </div>
-
-            <div id="scenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force"
-                 class="collapse property-definition-div" aria-labelledby="headingscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force"
-                 data-parent="#accordionscenarios_array_items__steps_array_items__option3__podAction__actions_array_items__option5__stopHost__force">
-              <div class="card-body">
-                <span class="badge badge-dark value-type">Type: boolean</span>
-
-            
-              </div>
-            </div>
-        </div>
     </div>
               </div>
             </div>

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: powerfulseal
           imagePullPolicy: Always
-          image: bloomberg/powerfulseal:3.0.0rc10
+          image: bloomberg/powerfulseal:3.0.0rc11
           args:
           - autonomous
           - --policy-file=/policy.yml

--- a/powerfulseal/k8s/k8s_client.py
+++ b/powerfulseal/k8s/k8s_client.py
@@ -214,7 +214,11 @@ class K8sClient():
             out = []
             for scenario in scenarios['items']:
                 out.append(scenario['spec'])
+            self.logger.info("Read %d scenarios from CRDS", len(out))
             return out
         except ApiException as e:
+            if e.status == 403:
+                self.logger.info("No permission to list powerfulseal CRDs. Ignoring.")
+                return []
             self.logger.exception(e)
             raise

--- a/powerfulseal/policy/action_nodes.py
+++ b/powerfulseal/policy/action_nodes.py
@@ -35,7 +35,6 @@ class ActionNodes(ActionNodesPods):
             "wait": self.action_wait,
             "execute": self.action_execute,
         }
-        self.cleanup_actions = []
 
     def match(self):
         """ Makes a union of all the nodes matching any of the policy criteria.
@@ -117,6 +116,3 @@ class ActionNodes(ActionNodesPods):
                     self.metric_collector.add_execute_failed_metric(item)
                     success = False
         return success
-
-    def get_cleanup_actions(self):
-        return self.cleanup_actions

--- a/powerfulseal/policy/action_nodes_pods.py
+++ b/powerfulseal/policy/action_nodes_pods.py
@@ -209,6 +209,7 @@ class ActionNodesPods(ActionAbstract):
         sleep_time = params.get("seconds", 0)
         self.logger.info("Action sleep for %s seconds", sleep_time)
         time.sleep(sleep_time)
+        return True
 
     def act(self, items):
         """ Execute policy's actions on the items

--- a/powerfulseal/policy/action_nodes_pods.py
+++ b/powerfulseal/policy/action_nodes_pods.py
@@ -38,6 +38,7 @@ class ActionNodesPods(ActionAbstract):
         self.logger = logger or makeLogger(__name__, name)
         self.metric_collector = metric_collector or StdoutCollector()
         self.action_mapping = dict()
+        self.cleanup_actions = []
 
     def execute(self):
         """ Main entry point to starting a scenario.
@@ -229,4 +230,6 @@ class ActionNodesPods(ActionAbstract):
                         success = False
         return success
 
+    def get_cleanup_actions(self):
+        return self.cleanup_actions
 

--- a/powerfulseal/policy/action_pods.py
+++ b/powerfulseal/policy/action_pods.py
@@ -25,7 +25,7 @@ class StartHostAction():
     def __init__(self, driver, host, logger=None):
         self.driver = driver
         self.host = host
-        self.logger = logger
+        self.logger = logger or makeLogger(__name__)
 
     def execute(self):
         try:

--- a/powerfulseal/policy/action_pods.py
+++ b/powerfulseal/policy/action_pods.py
@@ -176,6 +176,7 @@ class ActionPods(ActionNodesPods):
     def action_stop_host(self, pods, params):
         """ Action to stop a node.
         """
+        self.inventory.sync()
         host_ips = list(set([p.host_ip for p in pods]))
         for host_ip in host_ips:
             host = self.inventory.get_node_by_ip(host_ip)

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -129,6 +129,7 @@ definitions:
           - "$ref": "#/definitions/podAction"
           - "$ref": "#/definitions/nodeAction"
           - "$ref": "#/definitions/waitAction"
+          - "$ref": "#/definitions/stopPodsHostAction"
     required:
     - name
     - steps
@@ -389,6 +390,27 @@ definitions:
         - seconds
     required:
     - wait
+
+
+  stopPodsHostAction:
+    description: >
+      Stops the host on which the pods are running.
+    type: object
+    additionalProperties: false
+    properties:
+      stopHost:
+        type: object
+        additionalProperties: false
+        properties:
+          force:
+            type: boolean
+          autoRestart:
+            type: boolean
+            description:
+              When set to true, the node will be restarted at the end of the scenario.
+            default: true
+    required:
+    - stopHost
 
 
 ###################################################################################################

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -129,7 +129,6 @@ definitions:
           - "$ref": "#/definitions/podAction"
           - "$ref": "#/definitions/nodeAction"
           - "$ref": "#/definitions/waitAction"
-          - "$ref": "#/definitions/stopPodsHostAction"
     required:
     - name
     - steps
@@ -228,6 +227,7 @@ definitions:
               - "$ref": "#/definitions/actionWait"
               - "$ref": "#/definitions/checkPodState"
               - "$ref": "#/definitions/checkPodCount"
+              - "$ref": "#/definitions/stopPodsHostAction"
         required:
         - matches
         - actions

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -402,8 +402,6 @@ definitions:
         type: object
         additionalProperties: false
         properties:
-          force:
-            type: boolean
           autoRestart:
             type: boolean
             description:

--- a/powerfulseal/policy/scenario.py
+++ b/powerfulseal/policy/scenario.py
@@ -74,7 +74,7 @@ class Scenario():
             return
         self.logger.info("Cleanup started (%d items)", len(self.cleanup_list))
         for action in self.cleanup_list:
-            self.execute_action(action)
+            action.execute()
         self.cleanup_list = []
         self.logger.info("Cleanup done")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.0.0rc10
+version = 3.0.0rc11
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -235,6 +235,10 @@ scenarios:
             probability: 1
             force: true
 
+        # stops the hosts the pods are running on
+        - stopHost:
+            autoRestart: true
+
 
   # check that there are two pods, and both running in luckywinner namespace
   - podAction:

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -66,7 +66,7 @@ scenarios:
               serviceAccountName: powerfulseal
               containers:
                 - name: powerfulseal
-                  image: bloomberg/powerfulseal:3.0.0rc10
+                  image: bloomberg/powerfulseal:3.0.0rc11
                   args:
                   - autonomous
                   - --policy-file=/policy.yml


### PR DESCRIPTION
## TL;DR

Often, you want to stop a host that runs a particular pod. Right now, you need to do some gymnastics to achieve that.
With `stopHost`, you can select all the pods you like, and stop all the hosts that are involved in running that set.

## Demo

This will restart the nodes at the end of the scenario

```yaml
scenarios:
- name: Hello chaos!
  steps:
  - podAction:
      matches:
        - namespace: something
      filters:
        - randomSample:
            size: 1
      actions:
        - stopHost:
            autoRestart: true
  - wait:
      seconds: 30
```