### PR TITLE
Added ARM64 support for generating ARM64 docker containers and added ARM64 support to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,4 @@ deploy:
       tags: true
       python: "3.7"
       condition: -n "$TWINE_PASSWORD"
+      arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python:
   - "3.7"
   - "3.8"
 
+arch:
+  - amd64
+  - arm64
+
 # enable docker in Travis
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ local_no_proxy ?= ""
 
 name ?= powerfulseal
 version ?= `python setup.py --version`
-tag = $(name):$(version)
+arch1=$(shell uname -m)
+ifeq ($(arch1),x86_64)
+  arch2=amd64
+else ifeq ($(arch1),aarch64)
+  arch2=arm64
+endif
+tag = $(name):$(version)-$(arch2)
 namespace ?= "bloomberg/"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,12 @@ local_no_proxy ?= ""
 
 name ?= powerfulseal
 version ?= `python setup.py --version`
-arch1=$(shell uname -m)
-ifeq ($(arch1),x86_64)
-  arch2=amd64
-else ifeq ($(arch1),aarch64)
-  arch2=arm64
+arch=$(shell uname -m)
+ifeq ($(arch),x86_64)
+  tag = $(name):$(version)
+else ifeq ($(arch),aarch64)
+  tag = $(name):$(version)-arm64
 endif
-tag = $(name):$(version)-$(arch2)
 namespace ?= "bloomberg/"
 
 test:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-slim-buster as builder
 
 # install all the build dependencies
 RUN apt-get update && \
-    apt-get install -y build-essential curl && \
+    apt-get install -y build-essential curl libffi-dev libssl-dev && \
     apt-get clean && \
     apt-get autoclean && \
     apt-get autoremove
@@ -13,7 +13,8 @@ ARG https_proxy
 ARG no_proxy
 
 # download kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl \
+RUN if [ `uname -m` = "aarch64" ] ; then KUBECTL_ARCH="arm64"; else KUBECTL_ARCH="amd64"; fi \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/${KUBECTL_ARCH}/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && kubectl version --client


### PR DESCRIPTION
Resolves #288 

1. ARM64 architecture has been added to .travis.yml file.
2. Installed libffi-dev and libssl-dev in the RUN clause of the Dockerfile for ARM64. libffi-dev and libssl-dev are required for installing pynacl package in ARM64.
3. Added a check in the RUN clause of the Dockerfile, for downloading kubectl binary according to the
host platform.

Signed-off-by: odidev <odidev@puresoftware.com>


