### PR TITLE
Don't self destruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ powerfulseal autonomous --policy-file ./policy.yaml
 
 ## Installing
 
-- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `docker pull bloomberg/powerfulseal:3.0.0rc12`
+- [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags): `docker pull bloomberg/powerfulseal:3.0.0rc13`
 - [pip](https://pypi.org/project/powerfulseal/): `pip install powerfulseal`
 
 

--- a/docs/2_getting-started.md
+++ b/docs/2_getting-started.md
@@ -85,7 +85,7 @@ For help, just type `help`. For more information about the modes, see our [docs 
 For each [release](https://github.com/bloomberg/powerfulseal/releases) a `docker` image is built and published to the [docker hub](https://hub.docker.com/r/bloomberg/powerfulseal/tags).
 
 ```sh
-docker pull bloomberg/powerfulseal:3.0.0rc12
+docker pull bloomberg/powerfulseal:3.0.0rc13
 ```
 
 ### Run docker image
@@ -97,7 +97,7 @@ Below is an example of using the `-v` flag to inject your local `kubeconfig` to 
 ```sh
 docker run -it \
     -v ~/.kube:/root/.kube \
-    bloomberg/powerfulseal:3.0.0rc12 \
+    bloomberg/powerfulseal:3.0.0rc13 \
     interactive
 ```
 

--- a/docs/4_policies.md
+++ b/docs/4_policies.md
@@ -104,3 +104,31 @@ scenarios: []
 ## Examples
 
 To see examples of policies, use the menu on the left.
+
+
+## Note on self-destruction
+
+With great power comes great responsibility, and sometimes it's easy to take down the wrong pod or node and kill it by accident.
+
+That's not idea, because it might result in nodes staying down, or incomplete experiments.
+
+To avoid that, PowerfulSeal honors two variables, that it will filter out from killing:
+
+```yaml
+          env:
+          # in order to allow PowerfulSeal to not accidentally self-destruct
+          # give it the pod name
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          # and the host ip
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+```
+
+Any pods with this name, and any hosts with that IP will be spared.

--- a/docs/policies/kubectl.md
+++ b/docs/policies/kubectl.md
@@ -66,7 +66,7 @@ scenarios:
             spec:
               containers:
                 - name: powerfulseal
-                  image: bloomberg/powerfulseal:3.0.0rc12
+                  image: bloomberg/powerfulseal:3.0.0rc13
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: powerfulseal
           imagePullPolicy: Always
-          image: bloomberg/powerfulseal:3.0.0rc12
+          image: bloomberg/powerfulseal:3.0.0rc13
           args:
           - autonomous
           - --policy-file=/policy.yml

--- a/kubernetes/powerfulseal.yml
+++ b/kubernetes/powerfulseal.yml
@@ -39,6 +39,20 @@ spec:
           - autonomous
           - --policy-file=/policy.yml
           - --prometheus-collector
+          env:
+          # in order to allow PowerfulSeal to not accidentally self-destruct
+          # give it the pod name
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          # and the host ip
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
           volumeMounts:
             - name: policyfile
               mountPath: /policy.yml

--- a/powerfulseal/policy/action_nodes_pods.py
+++ b/powerfulseal/policy/action_nodes_pods.py
@@ -97,8 +97,8 @@ class ActionNodesPods(ActionAbstract):
 
     def dont_self_destruct(self, items):
         """ Don't kill its own pod or node """
-        HOST_IP = os.environ.get("HOST_IP", "")
-        POD_NAME = os.environ.get("POD_NAME", os.environ.get("HOSTNAME", ""))
+        HOST_IP = os.environ.get("HOST_IP")
+        POD_NAME = os.environ.get("POD_NAME", os.environ.get("HOSTNAME"))
         attrs = dict(
             ip=HOST_IP,
             extIp=HOST_IP,
@@ -107,7 +107,7 @@ class ActionNodesPods(ActionAbstract):
         matches = set()
         for item in items:
             for attr, val in attrs.items():
-                if getattr(item, attr, None) == val:
+                if val and getattr(item, attr, None) == val:
                     matches.add(item)
         return [
             item

--- a/powerfulseal/policy/action_nodes_pods.py
+++ b/powerfulseal/policy/action_nodes_pods.py
@@ -15,6 +15,7 @@
 
 
 import time
+import os
 import re
 from datetime import datetime
 import calendar
@@ -94,6 +95,26 @@ class ActionNodesPods(ActionAbstract):
             for v in value
         ])
 
+    def dont_self_destruct(self, items):
+        """ Don't kill its own pod or node """
+        HOST_IP = os.environ.get("HOST_IP", "")
+        POD_NAME = os.environ.get("POD_NAME", os.environ.get("HOSTNAME", ""))
+        attrs = dict(
+            ip=HOST_IP,
+            extIp=HOST_IP,
+            name=POD_NAME,
+        )
+        matches = set()
+        for item in items:
+            for attr, val in attrs.items():
+                if getattr(item, attr, None) == val:
+                    matches.add(item)
+        return [
+            item
+            for item in items
+            if item not in matches
+        ]
+
     def filter(self, items):
         """ Applies various filters based on the given policy.
         """
@@ -104,6 +125,7 @@ class ActionNodesPods(ActionAbstract):
             "randomSample": self.filter_random_sample,
             "probability": self.filter_probability,
         }
+        items = self.dont_self_destruct(items)
         return self.filter_mapping(items, filters, mapping)
 
     def filter_property(self, candidates, criterion):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.0.0rc12
+version = 3.0.0rc13
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters

--- a/tests/policy/example_config.yml
+++ b/tests/policy/example_config.yml
@@ -66,7 +66,7 @@ scenarios:
               serviceAccountName: powerfulseal
               containers:
                 - name: powerfulseal
-                  image: bloomberg/powerfulseal:3.0.0rc12
+                  image: bloomberg/powerfulseal:3.0.0rc13
                   args:
                   - autonomous
                   - --policy-file=/policy.yml

--- a/tests/policy/test_action_nodes.py
+++ b/tests/policy/test_action_nodes.py
@@ -198,11 +198,16 @@ def test_doesnt_stop_itself(node_scenario):
     mock_item.ip = "1.2.3.4"
     mock_item2 = MagicMock()
     mock_item2.extIp = "1.2.3.5"
-    node_scenario.match = MagicMock(return_value=[mock_item, mock_item2])
+    mock_item3 = MagicMock()
+    mock_item3.ip = "1.2.3.5"
+    mock_item4 = MagicMock()
+    mock_item4.extIp = "1.2.3.4"
+    node_scenario.match = MagicMock(return_value=[mock_item, mock_item2, mock_item3, mock_item4])
     node_scenario.act = MagicMock()
     node_scenario.execute()
+    print(node_scenario.act.call_args_list)
     assert node_scenario.act.call_count == 1
     for _, call in enumerate(node_scenario.act.call_args_list):
         args, kwargs = call
-        assert args == ([mock_item2],)
+        assert args == ([mock_item2, mock_item3],)
         assert kwargs == {}

--- a/tests/policy/test_action_nodes.py
+++ b/tests/policy/test_action_nodes.py
@@ -187,13 +187,6 @@ def test_action_stop_doesnt_create_cleanup_action(node_scenario):
 
 @patch.dict(os.environ, {"HOST_IP": "1.2.3.4"})
 def test_doesnt_stop_itself(node_scenario):
-    node_scenario.schema["actions"] = [
-        dict(
-            stop=dict(
-                autoRestart=False
-            )
-        )
-    ]
     mock_item = MagicMock()
     mock_item.ip = "1.2.3.4"
     mock_item2 = MagicMock()

--- a/tests/policy/test_action_pods.py
+++ b/tests/policy/test_action_pods.py
@@ -182,15 +182,6 @@ def test_doesnt_kill_when_cant_find_node(pod_scenario):
 
 @patch.dict(os.environ, {"POD_NAME": "powerfulseal-asyxoy2-sdaf"})
 def test_doesnt_kill_itself(pod_scenario):
-    pod_scenario.schema = {
-        "actions": [
-            {
-                "kill": {
-                    "force": True
-                }
-            },
-        ]
-    }
     mock_item = MagicMock()
     mock_item.name = "powerfulseal-asyxoy2-sdaf"
     mock_item2 = MagicMock()


### PR DESCRIPTION
Currently, it's a little bit too easy to shoot yourself in the foot by killing the pod or the host that PowerfulSeal is running on.

This prevents it from happening, as long as you provide the `HOST_IP` and `POD_NAME` environment variables.